### PR TITLE
Partial "fix" to #77 .

### DIFF
--- a/Assets/XML/GlobalDefinesAlt.xml
+++ b/Assets/XML/GlobalDefinesAlt.xml
@@ -171,7 +171,7 @@
 	</Define>
 	<Define>
 		<DefineName>LBD_CHANCE_INCREASE_EXPERT</DefineName>
-		<iDefineIntVal>1</iDefineIntVal>
+		<iDefineIntVal>5</iDefineIntVal>
 	</Define>
 	<Define>
 		<DefineName>LBD_PRE_ROUNDS_EXPERT</DefineName>

--- a/Assets/XML/Units/CIV4ProfessionInfos.xml
+++ b/Assets/XML/Units/CIV4ProfessionInfos.xml
@@ -559,7 +559,7 @@
 			</YieldsConsumed>
 			<Button>,Art/Colonization_Civilizations_Leaders.dds,6,8</Button>
 			<bUseLbD>1</bUseLbD>
-			<ExpertUnit>UNITCLASS_TRAPPER</ExpertUnit>
+			<ExpertUnit>UNITCLASS_SEALS_HUNTER</ExpertUnit>
 			<iLbDLearnLevel>2</iLbDLearnLevel>
 		</ProfessionInfo>
 		<ProfessionInfo>
@@ -1634,7 +1634,7 @@
 			<Button>,Art/colonization_atlas_professions_bonus.dds,4,6</Button>
 			<bUseLbD>1</bUseLbD>
 			<ExpertUnit>UNITCLASS_FURNITURE_MAKER</ExpertUnit>
-			<iLbDLearnLevel>3</iLbDLearnLevel>
+			<iLbDLearnLevel>2</iLbDLearnLevel>
 		</ProfessionInfo>
 		<ProfessionInfo>
 			<Type>PROFESSION_BLACKSMITH</Type>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -22838,7 +22838,7 @@
 			<bHiddenNationality>0</bHiddenNationality>
 			<bAlwaysHostile>0</bAlwaysHostile>
 			<bTreasure>0</bTreasure>
-			<bLbDCanBecomeExpert>0</bLbDCanBecomeExpert>
+			<bLbDCanBecomeExpert>1</bLbDCanBecomeExpert>
 			<bLbDCanGetFree>0</bLbDCanGetFree>
 			<bLbDCanEscape>0</bLbDCanEscape>
 			<UnitClassUpgrades/>

--- a/Project Files/DLLSources/CvCity.cpp
+++ b/Project Files/DLLSources/CvCity.cpp
@@ -10832,7 +10832,6 @@ bool CvCity::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, int
 
 	int calculatedChance = (base + (workedRounds - pre_rounds) * increase / l_level);
 	
-
 	if(!isHuman())
 	{
 		int ki_modifier = GC.getLBD_KI_MOD_EXPERT();

--- a/Project Files/DLLSources/CvCity.cpp
+++ b/Project Files/DLLSources/CvCity.cpp
@@ -125,7 +125,7 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits)
 	CvPlot* pAdjacentPlot;
 	CvPlot* pPlot;
 	BuildingTypes eLoopBuilding;
-
+	
 	pPlot = GC.getMapINLINE().plotINLINE(iX, iY);
 
 	//--------------------------------
@@ -236,7 +236,7 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits)
 	{
 		setTeachUnitClass(bestTeachUnitClass());
 	}
-
+	
 	setEverOwned(getOwnerINLINE(), true);
 
 	updateCultureLevel();
@@ -341,12 +341,12 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits)
 			changeOverflowProduction(GC.getDefineINT("INITIAL_AI_CITY_PRODUCTION"), 0);
 		}
 	}
-
-
+	
+	
 	for (int i = 0; i < MAX_PLAYERS; ++i)
 	{
 		CvPlayerAI& kPlayer = GET_PLAYER((PlayerTypes) i );
-
+		
 		if (kPlayer.isAlive())
 		{
 			kPlayer.AI_invalidateCloseBordersAttitudeCache();
@@ -355,7 +355,7 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits)
 	}
 
 	UpdateBuildingAffectedCache(); // building affected cache - Nightinggale
-
+	
 	GET_PLAYER(getOwnerINLINE()).AI_invalidateDistanceMap();
 	AI_init();
 }
@@ -735,7 +735,7 @@ void CvCity::doTurn()
 	doCulture();
 	doPlotCulture(false, getOwnerINLINE(), getCultureRate());
 	doProduction(bAllowNoProduction);
-
+	
 	if (!isNative())
 	{
 		doExtraCityDefenseAttacks(); // R&R, ray, Extra City Defense Attacks
@@ -744,7 +744,7 @@ void CvCity::doTurn()
 		doPrices(); // R&R, Androrc Domestic Market
 		doCityHealth(); // R&R, ray, Health
 	}
-
+	
 	doDecay();
 
 	doMissionaries();
@@ -1027,7 +1027,7 @@ void CvCity::doTask(TaskTypes eTask, int iData1, int iData2, bool bOption, bool 
 		}
 		// R&R mod, vetiarvind, max yield import limit - end
 
-
+		
 		setImportsMaintain((YieldTypes) iData1, bShift);
 		if (!bOption)
 		{
@@ -1868,7 +1868,7 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, bool bContinue, bool bTestVis
 			return false;
 		}
 	}
-
+	
 	return true;
 }
 
@@ -2671,7 +2671,7 @@ bool CvCity::canHurry(HurryTypes eHurry, bool bTestVisible) const
 				if (eProductionUnit != NO_UNIT)
 				{
 					UnitAITypes eDefaultUnitAI = (UnitAITypes)GC.getUnitInfo(eProductionUnit).getDefaultUnitAIType();
-
+				
 					if ((eDefaultUnitAI != kPlayer.AI_bestBuildupUnitAI()) && (eDefaultUnitAI != UNITAI_WAGON))
 					{
 						return false;
@@ -2719,7 +2719,7 @@ void CvCity::hurry(HurryTypes eHurry)
 		if (eProductionUnit != NO_UNIT)
 		{
 			UnitAITypes eDefaultUnitAI = (UnitAITypes)GC.getUnitInfo(eProductionUnit).getDefaultUnitAIType();
-
+		
 			if (eDefaultUnitAI == kPlayer.AI_bestBuildupUnitAI())
 			{
 				kPlayer.AI_clearStrategy(STRATEGY_MILITARY_BUILDUP);
@@ -2976,7 +2976,7 @@ int CvCity::getHurryCost(bool bExtra, int iProductionLeft, int iHurryModifier, i
 		if (iExtraProduction > 0)
 		{
 			int iAdjustedProd = iProduction * iProduction;
-
+			
 			// round up
 			iProduction = (iAdjustedProd + (iExtraProduction - 1)) / iExtraProduction;
 		}
@@ -2999,7 +2999,7 @@ int CvCity::hurryGold(HurryTypes eHurry) const
 			iGold += getHurryYieldDeficit(eHurry, eYield) * GET_PLAYER(eParent).getYieldSellPrice(eYield) * GC.getHurryInfo(eHurry).getYieldCostEuropePercent() / 100;
 		}
 	}
-
+	
 	if (!isHuman())
 	{
 		iGold *= GC.getHandicapInfo(GC.getGameINLINE().getHandicapType()).getAIHurryPercent();
@@ -3869,7 +3869,7 @@ void CvCity::setProductionAutomated(bool bNewValue, bool bClear)
 				clearOrderQueue();
 			}
 		}
-
+		
 		if (!isProduction())
 		{
 			AI_chooseProduction();
@@ -4355,7 +4355,7 @@ int CvCity::getBaseYieldRateModifier(YieldTypes eIndex, int iExtra) const
 	iModifier += GET_PLAYER(getOwnerINLINE()).getTaxYieldRateModifier(eIndex);
 
 	iModifier += getRebelPercent() * GC.getMAX_REBEL_YIELD_MODIFIER() / 100;
-
+	
 	// R&R, ray, Health
 	iModifier += getCityHealth(); // negative CityHealth is possible
 
@@ -4393,10 +4393,10 @@ int CvCity::getCultureRate() const
 
 	int totalNewCulture = 0;
 	int cultureFromPopulation = 0;
-
+	
 	if (!isNative()) // R&R, ray, Culture from Population not for Natives
 	{
-		cultureFromPopulation = getPopulation() / 3;
+		cultureFromPopulation = getPopulation() / 3; 
 	}
 	totalNewCulture = cultureFromPopulation + calculateNetYield(eYield);
 
@@ -4453,7 +4453,7 @@ int CvCity::getProductionOutput(ProfessionTypes eProfession) const
 	FAssert(GC.getProfessionInfo(eProfession).isCitizen());
 
 	CvProfessionInfo& kProfession = GC.getProfessionInfo(eProfession);
-
+	
 	int iOutput = 0;
 
 	if (kProfession.isWorkPlot())
@@ -4484,7 +4484,7 @@ int CvCity::getPotentialProductionOutput(ProfessionTypes eProfession) const
 	FAssert(GC.getProfessionInfo(eProfession).isCitizen());
 
 	CvProfessionInfo& kProfession = GC.getProfessionInfo(eProfession);
-
+	
 	// R&R, ray , MYCP partially based on code of Aymerick - START
 	YieldTypes eYieldProduced = (YieldTypes)kProfession.getYieldsProduced(0);
 	// R&R, ray , MYCP partially based on code of Aymerick - END
@@ -4506,7 +4506,7 @@ int CvCity::getPotentialProductionOutput(ProfessionTypes eProfession) const
 				{
 					YieldTypes eBestYield = NO_YIELD;
 					int iBestOutput = 0;
-
+					
 					for (int iJ = 0; iJ < NUM_YIELD_TYPES; iJ++)
 					{
 						if ((iJ != YIELD_FOOD) && (iJ != YIELD_LUMBER))
@@ -4519,7 +4519,7 @@ int CvCity::getPotentialProductionOutput(ProfessionTypes eProfession) const
 							}
 						}
 					}
-
+					
 					if (eBestYield == eYieldProduced)
 					{
 						iOutput += iBestOutput;
@@ -4560,7 +4560,7 @@ bool CvCity::hasOtherProductionBuilding(BuildingTypes eBuilding, int iMax) const
 	for (int i = 0; i < GC.getNumProfessionInfos(); ++i)
 	{
 		CvProfessionInfo& kProfession = GC.getProfessionInfo((ProfessionTypes)i);
-
+		
 		if (GC.getCivilizationInfo(kOwner.getCivilizationType()).isValidProfession(i))
 		{
 			if (kProfession.getSpecialBuilding() != kBuildingInfo.getSpecialBuildingType())
@@ -4568,7 +4568,7 @@ bool CvCity::hasOtherProductionBuilding(BuildingTypes eBuilding, int iMax) const
 				// R&R, ray , MYCP partially based on code of Aymerick - START
 				YieldTypes eYieldProduced = (YieldTypes)kProfession.getYieldsProduced(0);
 				// R&R, ray , MYCP partially based on code of Aymerick - END
-
+				
 				if (eYieldProduced != NO_YIELD && GC.getYieldInfo(eYieldProduced).isCargo())
 				{
 					for (int iBuildingClass = 0; iBuildingClass < GC.getNumBuildingClassInfos(); ++iBuildingClass)
@@ -4858,7 +4858,7 @@ void CvCity::changeYieldRushed(YieldTypes eYield, int iChange)
 void CvCity::calculateNetYields(int aiYields[NUM_YIELD_TYPES], int* aiProducedYields, int* aiConsumedYields, bool bPrintWarning) const
 {
 	PROFILE_FUNC();
-
+	
 	int aiConsumed[NUM_YIELD_TYPES];
 	int aiProduced[NUM_YIELD_TYPES];
 	if (aiProducedYields == NULL)
@@ -4903,7 +4903,7 @@ void CvCity::calculateNetYields(int aiYields[NUM_YIELD_TYPES], int* aiProducedYi
 		for (int iUnitIndex = 0; iUnitIndex < (int)m_aPopulationUnits.size(); ++iUnitIndex)
 		{
 			CvUnit* pUnit = m_aPopulationUnits[iUnitIndex];
-
+			
 			if (pUnit->getProfession() != NO_PROFESSION)
 			{
 				CvProfessionInfo& kProfession = GC.getProfessionInfo(pUnit->getProfession());
@@ -4911,7 +4911,7 @@ void CvCity::calculateNetYields(int aiYields[NUM_YIELD_TYPES], int* aiProducedYi
 				{
 					YieldTypes eYieldProduced = (YieldTypes) kProfession.getYieldsProduced(0);
 					CvPlot* pCurrentWorkedPlot = getPlotWorkedByUnit(pUnit);
-
+				
 					if (pCurrentWorkedPlot != NULL)
 					{
 						int availableAmountOfYield = pCurrentWorkedPlot->calculatePotentialProfessionYieldAmount(pUnit->getProfession(), pUnit, false);
@@ -4950,7 +4950,7 @@ void CvCity::calculateNetYields(int aiYields[NUM_YIELD_TYPES], int* aiProducedYi
 								setUnsatisfiedProfessions.insert(pUnit->getProfession());
 							}
 							*/
-
+							
 							if (bPrintWarning && (aiProducedYields[eYieldConsumed] == 0 || aiProducedYields[eYieldConsumed2] == 0))
 							{
 								setUnsatisfiedProfessions.insert(pUnit->getProfession());
@@ -5011,7 +5011,7 @@ void CvCity::calculateNetYields(int aiYields[NUM_YIELD_TYPES], int* aiProducedYi
 								setUnsatisfiedProfessions.insert(pUnit->getProfession());
 							}
 							*/
-
+							
 							if (bPrintWarning && aiProducedYields[eYieldConsumed] == 0)
 							{
 								setUnsatisfiedProfessions.insert(pUnit->getProfession());
@@ -5086,7 +5086,7 @@ void CvCity::calculateNetYields(int aiYields[NUM_YIELD_TYPES], int* aiProducedYi
 	{
 		aiYields[eImmigrationYield] += aiYields[YIELD_CROSSES];
 	}
-
+	
 	for (std::set<ProfessionTypes>::iterator it = setUnsatisfiedProfessions.begin(); it != setUnsatisfiedProfessions.end(); ++it)
 	{
 		CvProfessionInfo& kProfession = GC.getProfessionInfo(*it);
@@ -5706,7 +5706,7 @@ void CvCity::setUnitWorkingPlot(int iPlotIndex, int iUnitId)
 			return;
 		}
 		ProfessionTypes eUnitProfession = pUnit->getProfession();
-
+		
 		FAssert(pUnit->isColonistLocked() || !isUnitWorkingAnyPlot(pUnit));
 		if (pUnit->isColonistLocked())
 		{
@@ -5732,7 +5732,7 @@ void CvCity::setUnitWorkingPlot(int iPlotIndex, int iUnitId)
 					}
 				}
 
-				// Erik: No assert since it is possible that a unit would produce 0 yield in any plot profession
+				// Erik: No assert since it is possible that a unit would produce 0 yield in any plot profession 
 				//FAssert(eBestProfession != NO_PROFESSION);
 				if(eBestProfession != NO_PROFESSION)
 				{
@@ -5747,7 +5747,7 @@ void CvCity::setUnitWorkingPlot(int iPlotIndex, int iUnitId)
 				clearUnitWorkingPlot(pCurrentWorkedPlot);
 			}
 		}
-
+		
 		m_paiWorkingPlot[iPlotIndex] = iUnitId;
 
 		FAssertMsg(pPlot->getWorkingCity() == this, "WorkingCity is expected to be this");
@@ -5761,8 +5761,8 @@ void CvCity::setUnitWorkingPlot(int iPlotIndex, int iUnitId)
 		if ((getTeam() == GC.getGameINLINE().getActiveTeam()) || GC.getGameINLINE().isDebugMode())
 		{
 			pPlot->updateSymbolDisplay();
-		}
-
+		}	
+		
 		if (isCitySelected())
 		{
 			gDLL->getInterfaceIFace()->setDirty(InfoPane_DIRTY_BIT, true );
@@ -5788,7 +5788,7 @@ void CvCity::clearUnitWorkingPlot(int iPlotIndex)
 	if (pPlot != NULL)
 	{
 		m_paiWorkingPlot[iPlotIndex] = -1;
-
+		
 		FAssertMsg(pPlot->getWorkingCity() == this, "WorkingCity is expected to be this");
 
 		setYieldRateDirty();
@@ -5800,7 +5800,7 @@ void CvCity::clearUnitWorkingPlot(int iPlotIndex)
 		if ((getTeam() == GC.getGameINLINE().getActiveTeam()) || GC.getGameINLINE().isDebugMode())
 		{
 			pPlot->updateSymbolDisplay();
-		}
+		}	
 
 		if (isCitySelected())
 		{
@@ -6007,7 +6007,7 @@ void CvCity::alterUnitProfession(int iUnitId, ProfessionTypes eProfession)
 		{
 			pUnit->setColonistLocked(true);
 			pUnit->setProfession(eProfession);
-
+			
 			if (GC.getProfessionInfo(eProfession).isWorkPlot())
 			{
 				if (!isUnitWorkingAnyPlot(pUnit))
@@ -6038,7 +6038,7 @@ void CvCity::ejectToTransport(int iUnitId, int iTransportId)
 				pUnit->loadUnit(pTransport);
 			}
 		}
-	}
+	}	
 }
 
 void CvCity::replaceCitizen(int iUnitId, int iReplacedUnitId, bool bAskProfession)
@@ -6313,7 +6313,7 @@ bool CvCity::isDominantSpecialBuilding(BuildingTypes eIndex) const
 {
 	FAssert((eIndex >= 0) && (eIndex < GC.getNumBuildingInfos()));
 	CvBuildingInfo& kBuilding = GC.getBuildingInfo(eIndex);
-
+	
 	//Walk through all the possible buildings in the building slot of the given building ...
 	//... and check if the given building is the building with the highest tier (SpecialBuildingPriority), built in that slot.
 	BuildingTypes eNextBuilding = (BuildingTypes) kBuilding.getIndexOf_NextBuildingType_In_SpecialBuilding();
@@ -6671,7 +6671,7 @@ bool CvCity::checkRequiredYields(OrderTypes eOrder, int iData1) const
 	{
 		YieldTypes eYield = (YieldTypes) iYield;
 		if (GC.getYieldInfo(eYield).isCargo())
-		{
+		{	
 			int iAmount = 0;
 			switch (eOrder)
 			{
@@ -6742,7 +6742,7 @@ void CvCity::checkCompletedBuilds(YieldTypes eYield, int iChange)
 bool CvCity::processRequiredYields(int iNum)
 {
 	CLLNode<OrderData>* pOrderNode = headOrderQueueNode();
-
+	
 	for (int iCount = 0; pOrderNode != NULL; ++iCount)
 	{
 		if (iCount == iNum)
@@ -6766,7 +6766,7 @@ bool CvCity::processRequiredYields(int iNum)
 	{
 		YieldTypes eYield = (YieldTypes) iYield;
 		if (GC.getYieldInfo(eYield).isCargo())
-		{
+		{	
 			int iNeeded = 0;
 			switch (pOrderNode->m_data.eOrderType)
 			{
@@ -6927,7 +6927,7 @@ void CvCity::doGrowth()
 	int iDiff;
 
 	if (GC.getUSE_DO_GROWTH_CALLBACK()) // K-Mod. block unused python callbacks
-	{
+	{		
 		CyCity* pyCity = new CyCity(this);
 		CyArgsList argsList;
 		argsList.add(gDLL->getPythonIFace()->makePythonObject(pyCity));	// pass in city class
@@ -6999,8 +6999,8 @@ void CvCity::doYields()
 	int iTotalYields = getTotalYieldStored();
 //VET NewCapacity - end 4/9
 	int iMaxCapacity = getMaxYieldCapacity();
-
-
+	
+	
 	// R&R, ray, adjustment Domestic Markets
 	int iTotalProfitFromDomesticMarket = 0;
 	//bool hasMarket = isHasBuilding((SpecialBuildingTypes)GC.getDefineINT("BUILDING_MARKET"));
@@ -7028,7 +7028,7 @@ void CvCity::doYields()
 					GET_PLAYER(getOwnerINLINE()).changeGold(iProfit);
 					iTotalProfitFromDomesticMarket = iTotalProfitFromDomesticMarket + iProfit;
 					//GET_PLAYER(getOwnerINLINE()).changeYieldTradedTotal(eYield, iDemand);
-				}
+				}	
 			}
 		}
 		if (iTotalProfitFromDomesticMarket != 0 && GC.getDOMESTIC_SALES_MESSAGES() == 1)
@@ -7038,10 +7038,10 @@ void CvCity::doYields()
 		}
 	}
 	// R&R, ray, adjustment Domestic Markets, END
-
+	
 	// R&R, ray, adjustment for less Custom House messages
 	int iCustomHouseProfit = 0;
-
+	
 	for (int iYield = 0; iYield < NUM_YIELD_TYPES; ++iYield)
 	{
 		YieldTypes eYield = (YieldTypes) iYield;
@@ -7080,8 +7080,8 @@ void CvCity::doYields()
 							int iEducationNeeded = educationThreshold() - pLoopUnit->getYieldStored();
 
 							int rStudentOutput = std::max(iStudentOutput, 1);
-							int iTurns = std::max(0, (iEducationNeeded + rStudentOutput - 1) / rStudentOutput);  // round up
-
+							int iTurns = std::max(0, (iEducationNeeded + rStudentOutput - 1) / rStudentOutput);  // round up				
+					
 							if (iTurns == 2 || iTurns == 1) {
 								CvWString szBuffer = gDLL->getText("TXT_KEY_MISC_STUDENT_ALMOST_GRADUATED", iTurns, getNameKey(), GC.getBuildingInfo(eSchoolBuilding).getTextKeyWide());
 								gDLL->getInterfaceIFace()->addMessage(getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_CULTUREEXPANDS", MESSAGE_TYPE_MINOR_EVENT, GC.getYieldInfo(YIELD_EDUCATION).getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_WHITE"), getX_INLINE(), getY_INLINE(), true, true);
@@ -7116,7 +7116,7 @@ void CvCity::doYields()
 						{
 							sellThreshold = iMaxCapacity;
 						}
-						else
+						else 
 						{
 							sellThreshold = getCustomHouseSellThreshold(eYield);
 						}
@@ -7146,13 +7146,13 @@ void CvCity::doYields()
 //VET NewCapacity - end 6/9 -- ray fix
 					iExcess = getYieldStored(eYield) - iMaxCapacity;
 				}
-
+					
 				if (iExcess > 0)
 				{
 					int iLoss = std::max(GC.getCITY_YIELD_DECAY_PERCENT() * iExcess / 100, GC.getMIN_CITY_YIELD_DECAY());
 					iLoss = std::min(iLoss, iExcess);
 					changeYieldStored(eYield, -iLoss);
-
+					
 					// R&R, ray , Changes to Custom House - START
 					int iComparableProfitInEurope = GET_PLAYER(getOwnerINLINE()).getSellToEuropeProfit(eYield, iLoss);
 
@@ -7189,23 +7189,23 @@ void CvCity::doYields()
 						// R&R, ray , Changes to Custom House - START
 						// Selling with Custom House will get Trade Founding Father Points
 						// check if Custom House
-						if (bHasUnlockedTradeSettings)
+						if (bHasUnlockedTradeSettings) 
 						{
 							for (int i = 0; i < GC.getNumFatherPointInfos(); ++i)
 							{
 								//Divide by 2 because Custom House gives only half as Europe does
 								int iProfitForFatherPointsAtCustomHouse = iProfit / 2;
-
+							
 								FatherPointTypes ePointType = (FatherPointTypes) i;
 								GET_PLAYER(getOwnerINLINE()).changeFatherPoints(ePointType, iProfitForFatherPointsAtCustomHouse * GC.getFatherPointInfo(ePointType).getEuropeTradeGoldPointPercent() / 100 );
 							}
 
 							// R&R, ray, adjustment for less Custom House messages
-							iCustomHouseProfit = iCustomHouseProfit + iProfit;
+							iCustomHouseProfit = iCustomHouseProfit + iProfit; 
 							//CvWString szBuffer = gDLL->getText("TXT_KEY_GOODS_SOLD_CUSTOM_HOUSE", iLoss, GC.getYieldInfo(eYield).getChar(), getNameKey(), iProfit);
 							//gDLL->getInterfaceIFace()->addMessage(getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BUILD_BANK", MESSAGE_TYPE_MINOR_EVENT, GC.getYieldInfo(eYield).getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_WHITE"), getX_INLINE(), getY_INLINE(), true, true);
 						}
-						else
+						else 
 						{
 							CvWString szBuffer = gDLL->getText("TXT_KEY_GOODS_LOST_SOLD", iLoss, GC.getYieldInfo(eYield).getChar(), getNameKey(), iProfit);
 							gDLL->getInterfaceIFace()->addMessage(getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, NULL, MESSAGE_TYPE_MINOR_EVENT, GC.getYieldInfo(eYield).getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_WHITE"), getX_INLINE(), getY_INLINE(), true, true);
@@ -7727,7 +7727,7 @@ void CvCity::read(FDataStreamBase* pStream)
 		if (GC.getYieldInfo((YieldTypes)i).isCargo())
 			{m_iTotalYieldStored += m_aiYieldStored[i];}
 	}
-
+	
 //VET NewCapacity - begin 9/9
 	pStream->Read(NUM_YIELD_TYPES, m_aiYieldRushed);
 	// R&R, Androrc, Domestic Market
@@ -7796,7 +7796,7 @@ void CvCity::read(FDataStreamBase* pStream)
 		ma_tradeStopAutoImport.read(pStream, arrayBitmap & SAVE_BIT_IMPORT_STOP);
 		// transport feeder - end - Nightinggale
 		// R&R mod, vetiarvind, max yield import limit - start
-		ma_tradeMaxThreshold.read(pStream, arrayBitmap & SAVE_BIT_TRADE_MAX_THRESHOLD);
+		ma_tradeMaxThreshold.read(pStream, arrayBitmap & SAVE_BIT_TRADE_MAX_THRESHOLD); 
 		// R&R mod, vetiarvind, max yield import limit - end
 	} else {
 		int iNumYields;
@@ -7826,7 +7826,7 @@ void CvCity::read(FDataStreamBase* pStream)
 		}
 	}
 	// traderoute just-in-time - end - Nightinggale
-
+	
 	m_orderQueue.Read(pStream);
 
 	pStream->Read(&m_iPopulationRank);
@@ -7884,7 +7884,7 @@ void CvCity::write(FDataStreamBase* pStream)
 	// R&R mod, vetiarvind, max yield import limit - End
 	pStream->Write(arrayBitmap);
 	// just-in-time yield arrays - end - Nightinggale
-
+	
 	pStream->Write(m_iID);
 	pStream->Write(m_iX);
 	pStream->Write(m_iY);
@@ -8075,8 +8075,8 @@ void CvCity::getVisibleBuildings(std::list<BuildingTypes>& kChosenVisible, int& 
 	{
 		int iCityScaleMod =  ((int)(pow((float)getPopulation(), GC.getDefineFLOAT("GAME_CITY_SIZE_EXP_MODIFIER")))) * 2;
 		iTotalVisibleBuildings = (10 + iCityScaleMod);
-	}
-	else
+	} 
+	else 
 	{
 		float fLo = GC.getDefineFLOAT("GAME_CITY_SIZE_LINMAP_AT_0");
 		float fHi = GC.getDefineFLOAT("GAME_CITY_SIZE_LINMAP_AT_50");
@@ -8093,12 +8093,12 @@ void CvCity::getVisibleBuildings(std::list<BuildingTypes>& kChosenVisible, int& 
 	{
 		iNumUniques = iMaxNumUniques;
 	}
-	else
+	else 
 	{
 		iNumUniques = kVisible.size();
 	}
 	iNumGenerics = iTotalVisibleBuildings - iNumUniques + getCitySizeBoost();
-
+	
 	// return
 	iChosenNumGenerics = iNumGenerics;
 	for(int i = 0; i < iNumUniques; i++)
@@ -8127,7 +8127,7 @@ void CvCity::getVisibleEffects(ZoomLevelTypes eCurZoom, std::vector<const TCHAR*
 			kEffectNames.push_back("EFFECT_CITY_BIG_BURNING_SMOKE");
 		}
 		return;
-	}
+	} 
 }
 
 void CvCity::getCityBillboardSizeIconColors(NiColorA& kDotColor, NiColorA& kTextColor) const
@@ -8961,9 +8961,9 @@ int CvCity::getBestYieldsAmountAvailable(YieldTypes eYield, ProfessionTypes ePro
 	{
 		return 0;
 	}
-
+	
 	FAssert(eYield != NO_YIELD);
-
+	
 	int iBestYieldAvailable = 0;
 
 	if(pUnit != NULL)
@@ -9010,12 +9010,12 @@ void CvCity::addPopulationUnit(CvUnit* pUnit, ProfessionTypes eProfession)
 		FAssert(false);
 		return;
 	}
-
+	
 	if ((getPopulation() == 0) && (GC.getDefineINT("CONSUME_EQUIPMENT_ON_FOUND") != 0))
 	{
 		// Pioneers consume tools when founding
 		// must do this before joining the city
-		pUnit->setProfession(eProfession);
+		pUnit->setProfession(eProfession); 
 	}
 
 	CvUnit* pTransferUnit = GET_PLAYER(pUnit->getOwnerINLINE()).getAndRemoveUnit(pUnit->getID());
@@ -9026,7 +9026,7 @@ void CvCity::addPopulationUnit(CvUnit* pUnit, ProfessionTypes eProfession)
 	area()->changePower(getOwnerINLINE(), pTransferUnit->getPower());
 	setYieldRateDirty();
 	pTransferUnit->setProfession(eProfession);
-
+	
 	pTransferUnit->setColonistLocked(false);
 
 	updatePopulation(iOldPopulation);
@@ -9035,7 +9035,7 @@ void CvCity::addPopulationUnit(CvUnit* pUnit, ProfessionTypes eProfession)
 }
 
 bool CvCity::removePopulationUnit(CvUnit* pUnit, bool bDelete, ProfessionTypes eProfession, bool bConquest)
-{
+{	
 	int iUnitIndex = getPopulationUnitIndex(pUnit);
 	if(iUnitIndex < 0)
 	{
@@ -9095,7 +9095,7 @@ bool CvCity::removePopulationUnit(CvUnit* pUnit, bool bDelete, ProfessionTypes e
 		CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_TEXT);
 		pInfo->setText(gDLL->getText("ABANDONING_CITY"));
 		gDLL->getInterfaceIFace()->addPopup(pInfo, getOwnerINLINE(), true, true);
-
+		
 	}
 	// R&R Abandon City, ray END
 
@@ -9162,7 +9162,7 @@ CvUnit* CvCity::getPopulationUnitByIndex(int iUnitIndex) const
 	{
 		return m_aPopulationUnits[iUnitIndex];
 	}
-
+	
 	FAssert(false);
 	return NULL;
 }
@@ -9235,7 +9235,7 @@ void CvCity::setOrderedStudents(UnitTypes eUnit, int iCount, bool bRepeat, bool 
 			FAssert(iCount < 0);
 			return;
 		}
-
+	
 		ma_OrderedStudents.set(iCount, eUnit);
 		ma_OrderedStudentsRepeat.set(bRepeat, eUnit);
 		if (bUpdateRepeat && iCount == 0)
@@ -9350,7 +9350,7 @@ bool CvCity::canProduceYield(YieldTypes eYield)
 			}
 		}
 	}
-
+	
 	return false;
 }
 
@@ -9381,7 +9381,7 @@ int CvCity::getMaxYieldCapacityUncached() const
 				iCapacity /= 100;
 			}
 		}
-	}
+	}			
 
 	return iCapacity;
 }
@@ -9638,7 +9638,7 @@ int CvCity::getCityHealthChangeFromPopulation() const
 	int iNegHealthFromPopulation = 0;
 	int iCityPopulation = getPopulation();
 	int iMinCityPopForNegHealth = GC.getMIN_POP_NEG_HEALTH();
-
+	
 	// Negative Influence from Population only for human player
 	if (isHuman() && iCityPopulation >= iMinCityPopForNegHealth)
 	{
@@ -9679,9 +9679,9 @@ int CvCity::getCityHealthChange() const
 			return 0;
 		}
 	}
-
+	
 	return (iPosHealthFromHealers - iNegHealthFromPopulation);
-
+	
 }
 
 void CvCity::setCityHealth(int iValue)
@@ -9715,7 +9715,7 @@ void CvCity::changeCityHealth(int iValue)
 }
 
 void CvCity::doCityHealth()
-{
+{	
 		changeCityHealth(getCityHealthChange());
 }
 // R&R, ray, Health - END
@@ -9758,7 +9758,7 @@ int CvCity::educationThreshold() const
 void CvCity::setRebelSentiment(int iValue)
 {
 	m_iRebelSentiment = iValue;
-	FAssert(getRebelSentiment() >= 0);
+	FAssert(getRebelSentiment() >= 0);	
 }
 
 UnitClassTypes CvCity::bestTeachUnitClass()
@@ -9766,9 +9766,9 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 	PROFILE_FUNC();
 	int iBestValue = 0;
 	UnitClassTypes eBestUnitClass = NO_UNITCLASS;
-
+	
 	CvPlayerAI& kOwner = GET_PLAYER(getOwnerINLINE());
-
+	
 	std::vector<int> values(GC.getNumUnitClassInfos(), 0);
 	for (int i = 0; i < GC.getNumUnitClassInfos(); ++i)
 	{
@@ -9777,9 +9777,9 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 			UnitTypes eLoopUnit = (UnitTypes)GC.getUnitClassInfo((UnitClassTypes) i).getDefaultUnitIndex();
 			if (eLoopUnit != NO_UNIT)
 			{
-				int iValue = 0;
+				int iValue = 0;	
 				ProfessionTypes eIdealProfession = kOwner.AI_idealProfessionForUnit(eLoopUnit);
-
+		
 				if (eIdealProfession == NO_PROFESSION)
 				{
 					iValue += 100;
@@ -9787,7 +9787,7 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 				else
 				{
 					CvProfessionInfo& kIdealProfession = GC.getProfessionInfo(eIdealProfession);
-
+					
 					if (!kIdealProfession.isCitizen())
 					{
 						iValue += 100;
@@ -9809,7 +9809,7 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 						}
 						else
 						{
-
+						
 							int iPlotValue = 0;
 							for (int j = 0; j < NUM_CITY_PLOTS; ++j)
 							{
@@ -9823,7 +9823,7 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 										{
 											iPlotValue += 2;
 										}
-
+										
 										if (pLoopPlot->getFeatureType() != NO_FEATURE)
 										{
 											int iChange = GC.getFeatureInfo(pLoopPlot->getFeatureType()).getYieldChange(eWantedYield);
@@ -9847,18 +9847,18 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 									}
 								}
 							}
-
+							
 							iValue = 25 + 125 * iPlotValue / NUM_CITY_PLOTS;
 						}
 					}
 				}
-
+				
 				iValue *= GC.getCivilizationInfo(kOwner.getCivilizationType()).getTeachUnitClassWeight(i);
 				values[i] = iValue;
 			}
 		}
 	}
-
+	
 	int iTotal = 0;
 	int iCount = 0;
 	for (int i = 0; i < GC.getNumUnitClassInfos(); ++i)
@@ -9874,7 +9874,7 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 	{
 		return NO_UNITCLASS;
 	}
-
+	
 	int iLoop = 0;
 	CvCity* pLoopCity;
 	for (pLoopCity = kOwner.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kOwner.nextCity(&iLoop))
@@ -9885,7 +9885,7 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 			values[pLoopCity->getTeachUnitClass()] /= 2;
 		}
 	}
-
+	
 	//This dampens the favortism towards the most abundant yields.
 	int iAverage = iTotal / iCount;
 	for (int i = 0; i < GC.getNumUnitClassInfos(); ++i)
@@ -9898,7 +9898,7 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 				iValue = ((iValue - iAverage) / 4) + iAverage;
 			}
 			iValue = 1 + GC.getGameINLINE().getSorenRandNum(iValue, "Pick City Training");
-
+			
 			if (iValue > iBestValue)
 			{
 				iBestValue = iValue;
@@ -9906,7 +9906,7 @@ UnitClassTypes CvCity::bestTeachUnitClass()
 			}
 		}
 	}
-
+	
 	return eBestUnitClass;
 }
 
@@ -10034,7 +10034,7 @@ bool CvCity::canTradeAway(PlayerTypes eToPlayer) const
 }
 
 bool CvCity::educateStudent(int iUnitId, UnitTypes eUnit)
-{
+{	
 
 	CvUnit* pUnit = getPopulationUnitById(iUnitId);
 	if (pUnit == NULL)
@@ -10140,7 +10140,7 @@ int CvCity::getSpecialistTuition(UnitTypes eUnit) const
         return -1;
 	}
 	/** NBMOD EDU **/
-
+	
 	int* pMaxElement = std::max_element(m_aiSpecialistWeights, m_aiSpecialistWeights + GC.getNumUnitInfos());
 	int iBestWeight = *pMaxElement;
 	if (iBestWeight <= 0)
@@ -10171,16 +10171,16 @@ int CvCity::getSpecialistTuition(UnitTypes eUnit) const
 	{
 		iPrice *= GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getGrowthPercent();
 		iPrice /= 100;
-
+		
 		if (!isHuman())
 		{
 			iPrice *= GC.getHandicapInfo(GC.getGameINLINE().getHandicapType()).getAITrainPercent();
 			iPrice /= 100;
 		}
-
+	
 		iPrice *= iBestWeight - m_aiSpecialistWeights[eUnit];
 		iPrice /= iBestWeight;
-	}
+	} 
 	else
 	{
 		double fPrice = double(iPrice);
@@ -10219,7 +10219,7 @@ int CvCity::getSpecialistTuition(UnitTypes eUnit) const
 			iPrice = 0;
 		}
 	}
-
+	
 	for (int iTrait = 0; iTrait < GC.getNumTraitInfos(); ++iTrait)
 	{
 		TraitTypes eTrait = (TraitTypes) iTrait;
@@ -10276,7 +10276,7 @@ void CvCity::addExport(YieldTypes eYield, bool bUpdateRoutes)
 						}
 					}
 				}
-
+				
 				if (kRoutePlayer.isYieldEuropeTradable(eYield))
 				{
 					// TAC - AI Economy - koma13 - START
@@ -10579,8 +10579,8 @@ int CvCity::getMaintainLevel(YieldTypes eYield) const
 void CvCity::setImportsLimit(YieldTypes eYield, int iValue)
 {
 	if (getImportsLimit(eYield) != iValue)
-	{
-		ma_tradeMaxThreshold.set(iValue, eYield);
+	{		
+		ma_tradeMaxThreshold.set(iValue, eYield);		
 
 		if (getOwnerINLINE() == GC.getGameINLINE().getActivePlayer())
 		{
@@ -10590,8 +10590,8 @@ void CvCity::setImportsLimit(YieldTypes eYield, int iValue)
 }
 
 int CvCity::getImportsLimit(YieldTypes eYield) const
-{
-	return ma_tradeMaxThreshold.get(eYield);
+{		
+	return ma_tradeMaxThreshold.get(eYield);	
 }
 
 // R&R mod, vetiarvind, max yield import limit - End
@@ -10628,7 +10628,7 @@ void CvCity::checkImportsMaintain(YieldTypes eYield, bool bUpdateScreen)
 		FAssert(!isAutoImportStopped(eYield));
 		return;
 	}
-
+	
 	FAssertMsg(isImport(eYield), "Feeder service is active without import enabled");
 
 	int iMaintainLevel = getAutoMaintainThreshold(eYield);
@@ -10761,7 +10761,7 @@ void CvCity::handleAutoTraderouteSetup(bool bReset, bool bImportAll, bool bAutoE
 				bool bAutoExport     = bAutoExportAll || isAutoExport(eYield);
 				int iMaintainLevel   = getMaintainLevel(eYield);
 				int iImportLimitLevel= getImportsLimit(eYield);
-
+		
 				int iBuffer = iMaintainLevel & 0xFFFF; // lowest 16 bits
 				iBuffer |= (iImportLimitLevel & 0xFFFF) << 16; // next 16 bits
 
@@ -10806,8 +10806,8 @@ bool CvCity::isHasSpecialBuilding(int iValue)
 
 // TAC - LbD - Ray - START
 
-bool CvCity::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, int pre_rounds, int l_level)
-{
+bool CvCity::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, int pre_rounds, int l_level) 
+{	
 	// get data from Unit
 	int workedRounds = convUnit->getLbDrounds();
 	// this is a chance divisor if the unit changes professions.
@@ -10836,7 +10836,7 @@ bool CvCity::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, int
 		return false;
 	}
 
-	int calculatedChance = (base + (workedRounds - pre_rounds) * increase / l_level) ;
+	int calculatedChance = (base + (workedRounds - pre_rounds) * increase / l_level);
 	
 
 	if(!isHuman())
@@ -10844,7 +10844,7 @@ bool CvCity::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, int
 		int ki_modifier = GC.getLBD_KI_MOD_EXPERT();
 		calculatedChance = calculatedChance * ki_modifier / 100;
 	}
-
+	
 	for (int iTrait = 0; iTrait < GC.getNumTraitInfos(); ++iTrait)
 	{
 		TraitTypes eTrait = (TraitTypes) iTrait;
@@ -10861,17 +10861,17 @@ bool CvCity::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, int
 	//ray Multiplayer Random Fix
 	//int randomValue = rand() % 1000 + 1;
 	int randomValue = GC.getGameINLINE().getSorenRandNum(1000, "LbD Expert City");
-
+	
 	// no Success if randomValue larger calculatedChance
 	if (randomValue > calculatedChance)
 	{
 		return false;
 	}
-
+	
 	// convert Unit to expert
 	int expert = GC.getProfessionInfo(convUnit->getProfession()).LbD_getExpert();
 
-
+		
 	UnitTypes expertUnitType = (UnitTypes)GC.getCivilizationInfo(getCivilizationType()).getCivilizationUnits(expert);
 	FAssert(expertUnitType != NO_UNIT);
 	//ray16
@@ -10888,7 +10888,7 @@ bool CvCity::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, int
 	return true;
 }
 
-bool CvCity::LbD_try_get_free(CvUnit* convUnit, int base, int increase, int pre_rounds, int mod_crim, int mod_serv, int l_level)
+bool CvCity::LbD_try_get_free(CvUnit* convUnit, int base, int increase, int pre_rounds, int mod_crim, int mod_serv, int l_level) 
 {
 	// get data from Unit
 	int workedRounds = convUnit->getLbDrounds();
@@ -10902,7 +10902,7 @@ bool CvCity::LbD_try_get_free(CvUnit* convUnit, int base, int increase, int pre_
 
 	//workedRounds++;
 	convUnit->setLbDrounds(workedRounds + 1);
-
+	
 	// do not use feature if City Population = 1, because might destroy city
 	if (getPopulation() == 1)
 	{
@@ -10919,7 +10919,7 @@ bool CvCity::LbD_try_get_free(CvUnit* convUnit, int base, int increase, int pre_
 
 	//default case is servant
 	int mod = mod_serv;
-
+	
 	// if criminal
 	if (modcase == 2)
 	{
@@ -10927,17 +10927,17 @@ bool CvCity::LbD_try_get_free(CvUnit* convUnit, int base, int increase, int pre_
 	}
 
 	int calculatedChance = (base + (workedRounds - pre_rounds) * increase * l_level * mod);
-
+	
 	//ray Multiplayer Random Fix
 	//int randomValue = rand() % 1000 + 1;
 	int randomValue = GC.getGameINLINE().getSorenRandNum(1000, "LbD Free City");
-
+	
 	// no Success if randomValue larger calculatedChance
 	if (randomValue > calculatedChance)
 	{
 		return false;
 	}
-
+	
 	// convert Unit to Free Settler
 	UnitTypes DefaultUnitType = (UnitTypes)GC.getCivilizationInfo(getCivilizationType()).getCivilizationUnits(GC.getDefineINT("DEFAULT_POPULATION_UNIT"));
 	FAssert(DefaultUnitType != NO_UNIT);
@@ -10955,8 +10955,8 @@ bool CvCity::LbD_try_get_free(CvUnit* convUnit, int base, int increase, int pre_
 	return true;
 }
 
-bool CvCity::LbD_try_escape(CvUnit* convUnit, int base, int mod_crim, int mod_serv)
-{
+bool CvCity::LbD_try_escape(CvUnit* convUnit, int base, int mod_crim, int mod_serv) 
+{	
 	//Feature deactivated for KI
 	if (!isHuman()) {
 		return false;
@@ -10973,7 +10973,7 @@ bool CvCity::LbD_try_escape(CvUnit* convUnit, int base, int mod_crim, int mod_se
 
 	//default case is servant
 	int mod = mod_serv;
-
+	
 	// if criminal
 	if (modcase == 2)
 	{
@@ -10986,7 +10986,7 @@ bool CvCity::LbD_try_escape(CvUnit* convUnit, int base, int mod_crim, int mod_se
 	//ray Multiplayer Random Fix
 	//int randomValue = rand() % 1000 + 1;
 	int randomValue = GC.getGameINLINE().getSorenRandNum(1000, "LbD Escape City");
-
+	
 	// no Success if randomValue larger calculatedChance
 	if (randomValue > calculatedChance)
 	{
@@ -11001,7 +11001,7 @@ bool CvCity::LbD_try_escape(CvUnit* convUnit, int base, int mod_crim, int mod_se
 	//Unit is then simply destroyed
 	bool remove = removePopulationUnit(convUnit, false, (ProfessionTypes) GC.getCivilizationInfo(GET_PLAYER(getOwnerINLINE()).getCivilizationType()).getDefaultProfession());
 	convUnit->kill(false);
-
+	
 	// AddMessage
 	//ray16
 	CvWString szBuffer = gDLL->getText("TXT_KEY_LBD_ESCAPE", getNameKey());
@@ -11012,9 +11012,9 @@ bool CvCity::LbD_try_escape(CvUnit* convUnit, int base, int mod_crim, int mod_se
 }
 
 void CvCity::doLbD()
-{
+{	
 	//getting global values for formula
-	int base_chance_expert = GC.getLBD_BASE_CHANCE_EXPERT();
+	int base_chance_expert = GC.getLBD_BASE_CHANCE_EXPERT();	
 	int chance_increase_expert = GC.getLBD_CHANCE_INCREASE_EXPERT();
 	int pre_rounds_expert = GC.getLBD_PRE_ROUNDS_EXPERT();
 
@@ -11065,12 +11065,12 @@ void CvCity::doLbD()
 		bool lbd_expert_successful = false;
 		bool lbd_free_successful = false;
 		bool lbd_escape_successful = false;
-
+		
 
 		// only do something for this unit if the profession does use LbD
 		if (pLoopUnit->getProfession()!= NO_PROFESSION && GC.getProfessionInfo(pLoopUnit->getProfession()).LbD_isUsed())
 		{
-
+			
 			//get LearnLevel of profession
 			int learn_level = GC.getProfessionInfo(pLoopUnit->getProfession()).LbD_getLearnLevel();
 			// just for safety, catch possible XML mistakes which might break calculation
@@ -11078,7 +11078,7 @@ void CvCity::doLbD()
 			{
 				learn_level = 1;
 			}
-
+	
 			// try to become expert if poosible
 			if(pLoopUnit->getUnitInfo().LbD_canBecomeExpert())
 			{
@@ -11098,7 +11098,7 @@ void CvCity::doLbD()
 			}
 
 		}
-
+		
 	}
 
 }
@@ -11131,7 +11131,7 @@ void CvCity::doExtraCityDefenseAttacks()
 		{
 			pLoopUnit = ::getUnit(pUnitNode->m_data);
 			pUnitNode = plot()->nextUnitNode(pUnitNode);
-
+		
 			bool isCannonType = (pLoopUnit->bombardRate() > 0 && pLoopUnit->getDomainType() == DOMAIN_LAND);
 			if (isCannonType && pLoopUnit->getOwnerINLINE() == getOwnerINLINE())
 			{
@@ -11253,7 +11253,7 @@ void CvCity::doExtraCityDefenseAttacks()
 									}
 									//case water end
 
-									//case enemy is on land
+									//case enemy is on land 
 									if (!pAdjacentPlot->isWater())
 									{
 										if (iDamage > 0)
@@ -11363,7 +11363,7 @@ void CvCity::doExtraCityDefenseAttacks()
 						pAdjacentPlot = plotDirection(getX_INLINE(), getY_INLINE(), ((DirectionTypes)iI));
 						//we do not fire on Water here
 						if (pAdjacentPlot != NULL && !pAdjacentPlot->isWater())
-						{
+						{	
 							pUnitNode2 = pAdjacentPlot->headUnitNode();
 							while (pUnitNode2)
 							{
@@ -11387,9 +11387,9 @@ void CvCity::doExtraCityDefenseAttacks()
 										{
 											iDefenderCombatMod = 1;
 										}
-
+										
 										iDamage = iDamage / iDefenderCombatMod;
-
+										
 										//checking Terrain
 										int iTerrainDamageMod = 0;
 										if (pAdjacentPlot->isWater())
@@ -11418,7 +11418,7 @@ void CvCity::doExtraCityDefenseAttacks()
 										pLoopUnit2->changeDamage(iDamage, pDefenseUnit);
 									}
 
-									//case enemy is on land
+									//case enemy is on land 
 									if (!pAdjacentPlot->isWater())
 									{
 										if (iDamage > 0)
@@ -11651,7 +11651,7 @@ void CvCity::createFleeingUnit(UnitTypes eUnit)
 			if (pLoopPlot->area() != area())
 			{
 				iValue *= 3;
-			}
+			}	
 			if (iValue < iBestValue)
 			{
 				iBestValue = iValue;

--- a/Project Files/DLLSources/CvCity.cpp
+++ b/Project Files/DLLSources/CvCity.cpp
@@ -125,7 +125,7 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits)
 	CvPlot* pAdjacentPlot;
 	CvPlot* pPlot;
 	BuildingTypes eLoopBuilding;
-
+	
 	pPlot = GC.getMapINLINE().plotINLINE(iX, iY);
 
 	//--------------------------------

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -20415,7 +20415,7 @@ void CvPlayer::checkForNativeSlaves()
 					discount = 50;
 				}
 				int totalslaveprice = baseslaveprice - discount;
-
+				
 				//Gamespeed
 				int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
 
@@ -21575,7 +21575,7 @@ void CvPlayer::checkForConquistadors()
 					m_iTimerConquistador = GC.getTIMER_CONQUISTADOR() * gamespeedMod /100 ;
 					//create the conquistador
 					UnitTypes ConquistadorType;
-					int conquistUnitRand = GC.getGameINLINE().getSorenRandNum(3, "Conquistadors Available");
+					int conquistUnitRand = GC.getGameINLINE().getSorenRandNum(3, "Conquistadors Available");	
 					if (conquistUnitRand == 1)
 					{
 						ConquistadorType = (UnitTypes)GC.getCivilizationInfo(getCivilizationType()).getCivilizationUnits(GC.getDefineINT("UNITCLASS_MOUNTED_CONQUISTADOR"));

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -196,7 +196,7 @@ void CvPlayer::init(PlayerTypes eID)
 		setYieldAfricaBuyPrice(eYield, iAfricaBuyPrice, false);
 	}
 	// R&R, ray, Africa - END
-
+	
 	// R&R, ray, Port Royal
 	for (int iYield = 0; iYield < NUM_YIELD_TYPES; ++iYield)
 	{
@@ -719,9 +719,9 @@ void CvPlayer::initFreeState()
 	iStartingGold += GC.getEraInfo(GC.getGameINLINE().getStartEra()).getStartingGold();
 
 	// Gives an appropriate sum of money to trade with Natives, which depends on cargo size.
-	iStartingGold *= GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getStoragePercent();
+	iStartingGold *= GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getStoragePercent(); 
 	iStartingGold /= 100;
-
+	
 	changeGold(iStartingGold);
     // Barthoze : Time is the issue - END
 }
@@ -948,7 +948,7 @@ CvUnit* CvPlayer::addFreeUnit(UnitTypes eUnit, ProfessionTypes eProfession, Unit
 {
 	CvPlot* pStartingPlot = getStartingPlot();
 	if (pStartingPlot != NULL)
-	{
+	{		
 		pStartingPlot->setImprovementType(NO_IMPROVEMENT);//R&R, ray, bugfix for starting on Water Goody
 		CvUnit* pUnit = initUnit(eUnit, eProfession, pStartingPlot->getX_INLINE(), pStartingPlot->getY_INLINE(), eUnitAI);
 		return pUnit;
@@ -2357,7 +2357,7 @@ void CvPlayer::doTurn()
 	// TAC - LbD - Ray - START
 	doLbD();
 	// TAC - LbD - Ray - END
-
+	
 
 	// R&R, ray, changes to Wild Animals
 	if (!GC.getGameINLINE().isBarbarianPlayer(getID()) && !GC.getGameINLINE().isChurchPlayer(getID()) && !isNative() && !isEurope() && isAlive())
@@ -3348,14 +3348,14 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 			YieldTypes eYield = (YieldTypes) iData1;
 			kPlayer.setYieldEuropeTradable(eYield, false);
 			// R&R, ray, Improvements to Tax Mechanism - START
-			kPlayer.setYieldTradedTotal(eYield, 0);
-			kPlayer.setYieldScoreTotal(eYield, 0);// R&R, vetiarvind, price dependent tax rate change
+			kPlayer.setYieldTradedTotal(eYield, 0);			
+			kPlayer.setYieldScoreTotal(eYield, 0);// R&R, vetiarvind, price dependent tax rate change						 
 			for (int i = 0; i < NUM_YIELD_TYPES; i++)
 			{
 				if (kPlayer.isYieldEuropeTradable((YieldTypes)i))
 				{
 					kPlayer.setYieldTradedTotal((YieldTypes)i, 0);
-					kPlayer.setYieldScoreTotal((YieldTypes)i, 0);// R&R, vetiarvind, price dependent tax rate change
+					kPlayer.setYieldScoreTotal((YieldTypes)i, 0);// R&R, vetiarvind, price dependent tax rate change					 
 				}
 			}
 			// R&R, ray, Improvements to Tax Mechanism - END
@@ -3454,14 +3454,14 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 			{
 				//get City
 				int iLoop;
-				CvCity* locationToAppear = kPlayer.firstCity(&iLoop);
+				CvCity* locationToAppear = kPlayer.firstCity(&iLoop); 
 
 				if (locationToAppear != NULL)
 				{
 					UnitTypes SlaveType = (UnitTypes)GC.getCivilizationInfo(kPlayer.getCivilizationType()).getCivilizationUnits(GC.getDefineINT("UNITCLASS_NATIVE_SLAVE"));
 					CvUnit* SlaveUnit = kPlayer.initUnit(SlaveType, (ProfessionTypes) GC.getUnitInfo(SlaveType).getDefaultProfession(), locationToAppear->getX_INLINE(), locationToAppear->getY_INLINE(), NO_UNITAI);
-
-					//pay
+				
+					//pay 
 					changeGold(pricetopay);
 					kPlayer.changeGold(-pricetopay);
 
@@ -3486,7 +3486,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 			int totalslavesprice = baseslaveprice - discount;
 			int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
 			int pricetopay = numSlaves * totalslavesprice * gamespeedMod / 100;
-
+			
 			int availableGold = kPlayer.getGold();
 			if (availableGold >= pricetopay)
 			{
@@ -3530,7 +3530,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 
 			int availableGold = kPlayer.getGold();
 			if (availableGold >= pricetopay)
-			{
+			{	
 
 				//create the prisoners
 				//get City
@@ -3655,7 +3655,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 					//effects of choice
 					AI_changeAttitudeExtra(ePlayer, 1);
 
-					int effectRand = GC.getGameINLINE().getSorenRandNum(5, "ChurchEffectRand");
+					int effectRand = GC.getGameINLINE().getSorenRandNum(5, "ChurchEffectRand");	
 					switch (effectRand)
 					{
 						case 0:
@@ -3751,7 +3751,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 				//effects of choice
 				AI_changeAttitudeExtra(ePlayer, -1); // attitude of church
 
-				int effectRand = GC.getGameINLINE().getSorenRandNum(4, "ChurchEffectRand");
+				int effectRand = GC.getGameINLINE().getSorenRandNum(4, "ChurchEffectRand");	
 				switch (effectRand)
 				{
 					case 0:
@@ -3778,7 +3778,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 								{
 									kLoopPlayer.AI_changeAttitudeExtra(ePlayer, -1);
 								}
-							}
+							}	
 							szBuffer += gDLL->getText("TXT_KEY_CHURCH_PENALTY_ATTITUDE_EUROPEANS");
 							break;
 						}
@@ -3846,7 +3846,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 					{
 						CvPlayer& kEuropePlayer = GET_PLAYER((PlayerTypes) iData2);
 						kEuropePlayer.AI_changeAttitudeExtra(ePlayer, 1); //attitude of selected European improved
-
+		
 						CvWString szBuffer = gDLL->getText("TXT_KEY_CHURCH_SPOKE_FAVOUR_EUROPEAN", kEuropePlayer.getNameKey());
 						gDLL->getInterfaceIFace()->addMessage(ePlayer, false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_DEAL_CANCELLED", MESSAGE_TYPE_MINOR_EVENT, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_WHITE"), NULL, NULL, false, false);
 						break;
@@ -3855,7 +3855,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 						break;
 				}
 			}
-
+			
 		}
 		break;
 	// R&R, ray, Church Favours - END
@@ -3911,7 +3911,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 					CvUnit* ChurchReinforcementUnitInfantery = kPlayer.initUnit(ChurchReinforcementTypeInfantery, (ProfessionTypes) GC.getUnitInfo(ChurchReinforcementTypeInfantery).getDefaultProfession(), locationToAppear->getX_INLINE(), locationToAppear->getY_INLINE(), NO_UNITAI);
 					CvUnit* ChurchReinforcementUnitCavalery = kPlayer.initUnit(ChurchReinforcementTypeCavalery, (ProfessionTypes) GC.getUnitInfo(ChurchReinforcementTypeCavalery).getDefaultProfession(), locationToAppear->getX_INLINE(), locationToAppear->getY_INLINE(), NO_UNITAI);
 					CvUnit* ChurchReinforcementUnitArtillery = kPlayer.initUnit(ChurchReinforcementTypeArtillery, (ProfessionTypes) GC.getUnitInfo(ChurchReinforcementTypeArtillery).getDefaultProfession(), locationToAppear->getX_INLINE(), locationToAppear->getY_INLINE(), NO_UNITAI);
-
+					
 					//declaring limited war
 					GET_TEAM(kPlayer.getTeam()).declareWar(GET_PLAYER(enemyID).getTeam(),false, WARPLAN_LIMITED);
 
@@ -3923,7 +3923,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 
 			// we have chosen to disobey
 			else
-			{
+			{		
 				//improve relationship to the potential Native enemy
 				GET_PLAYER(enemyID).AI_changeAttitudeExtra(ePlayer, 2);
 
@@ -3957,7 +3957,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 					{
 						locationToAppear = pLoopCity;
 						break;
-					}
+					}			
 				}
 
 				if (locationToAppear!= NULL)
@@ -4375,8 +4375,8 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 			priceStealingImmigrant = priceStealingImmigrant * gamespeedMod / 100;
 
 			//getting the Data from Diplo-Event
-			PlayerTypes victimID = (PlayerTypes) iData1;
-
+			PlayerTypes victimID = (PlayerTypes) iData1; 
+			
 			CvPlayer& victimPlayer = GET_PLAYER(victimID); // European we steal Immigrant
 			CvPlayer& kPlayer = GET_PLAYER(ePlayer); // human Player
 
@@ -4471,7 +4471,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 			CvUnit* pUnit = getUnit(iData1);
 			int choice = iData2;
 			CvPlayer& kPlayer = GET_PLAYER(ePlayer);
-
+		
 			// bugfix start - Nightinggale
 			// don't assume that unit and cities exist just because they existed when the window was added to the pop-up queue
 			// failed assumtions leads to crashes
@@ -4538,7 +4538,7 @@ void CvPlayer::handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer
 			//pUnit->setYieldForNativeTrade(NO_YIELD);
 			//pUnit->setAmountForNativeTrade(0);
 			// R&R, vetiarvind, bug fix - END
-
+			
 
 		}
 		break;
@@ -5282,7 +5282,7 @@ bool CvPlayer::canReceiveGoody(CvPlot* pPlot, GoodyTypes eGoody, const CvUnit* p
 		// R&R, ray, Goodies on Water - START
 		if (pPlot->isWater())
 		{
-			if (pUnit == NULL)
+			if (pUnit == NULL) 
 			{
 				return false;
 			}
@@ -5668,7 +5668,7 @@ void CvPlayer::doGoody(CvPlot* pPlot, CvUnit* pUnit)
 							iRandValue = GC.getGameINLINE().getSorenRandNum(900, "Unit Goodies");
 						}
 						// R&R, ray, Goodies with units much less frequent - END
-
+						
 						if(iRandValue > iBestValue)
 						{
 							iBestValue = iRandValue;
@@ -6238,7 +6238,7 @@ void CvPlayer::processTrait(TraitTypes eTrait, int iChange)
 	changeNativeAngerModifier(kTrait.getNativeAngerModifier() * iChange);
 	changeNativeCombatModifier(kTrait.getNativeCombatModifier() * iChange);
 	changeMissionaryRateModifier(kTrait.getMissionaryModifier() * iChange);
-	changeNativeTradeModifier(kTrait.getNativeTradeModifier() * iChange); // R&R, ray, new Attribute in Traits
+	changeNativeTradeModifier(kTrait.getNativeTradeModifier() * iChange); // R&R, ray, new Attribute in Traits 
 
 	for (int iProfession = 0; iProfession < GC.getNumProfessionInfos(); ++iProfession)
 	{
@@ -6560,7 +6560,7 @@ int CvPlayer::getBuildCost(const CvPlot* pPlot, BuildTypes eBuild) const
 	FAssert(eBuild >= 0 && eBuild < GC.getNumBuildInfos());
 
 	int iCost;
-
+	
 	if (pPlot->getBuildProgress(eBuild) > 0)
 	{
 		iCost = 0;
@@ -7408,7 +7408,7 @@ void CvPlayer::setCombatExperience(int iExperience)
 						pBestCity->createGreatGeneral(eGeneralUnit, true);
 						setCombatExperience(getCombatExperience() - iExperienceThreshold);
 					}
-				}
+				}	
 			}
 			// R&R, ray, Great Admirals - END
 		}
@@ -7467,7 +7467,7 @@ void CvPlayer::setSeaCombatExperience(int iExperience)
 			}
 
 			if (pBestCity)
-			{
+			{				
 				UnitTypes eAdmiralUnit = (UnitTypes)GC.getCivilizationInfo(getCivilizationType()).getCivilizationUnits(GC.getDefineINT("UNITCLASS_GREAT_ADMIRAL"));
 				if (eAdmiralUnit != NO_UNIT)
 				{
@@ -7651,14 +7651,14 @@ void CvPlayer::setAlive(bool bNewValue)
 				CvTeamAI& ownTeam= GET_TEAM(getTeam());
 
 				for (int iTeam = 0; iTeam < MAX_TEAMS; ++iTeam)
-				{
+				{				
 					if (ownTeam.isAtWar((TeamTypes)iTeam))
 					{
 						if (ownTeam.canChangeWarPeace((TeamTypes)iTeam))
 						{
 							ownTeam.makePeace((TeamTypes) iTeam);
 						}
-					}
+					}		
 				}
 			}
 			// R&R, making peace with all factions, when dying - END
@@ -7776,7 +7776,7 @@ void CvPlayer::verifyAlive()
 							if (GET_PLAYER((PlayerTypes)iI).isAlive())
 							{
 								CvPlayer& kLoopPlayer = GET_PLAYER((PlayerTypes) iI);
-								if (kLoopPlayer.isNative())
+								if (kLoopPlayer.isNative()) 
 								{
 									int iLoop;
 									for (CvCity* pLoopCity = kLoopPlayer.firstCity(&iLoop); NULL != pLoopCity; pLoopCity = kLoopPlayer.nextCity(&iLoop))
@@ -12773,9 +12773,9 @@ void CvPlayer::read(FDataStreamBase* pStream)
 	}
 	// R&R, ray, Port Royal - END
 
-
-	m_aTradeGroups.Read(pStream); //R&R mod, vetiarvind, trade groups
-
+	
+	m_aTradeGroups.Read(pStream); //R&R mod, vetiarvind, trade groups	
+	
 
 	ReadStreamableFFreeListTrashArray(m_selectionGroups, pStream);
 	ReadStreamableFFreeListTrashArray(m_eventsTriggered, pStream);
@@ -13233,8 +13233,8 @@ void CvPlayer::write(FDataStreamBase* pStream)
 		m_aPortRoyalUnits[i]->write(pStream);
 	}
 	// R&R, ray, Port Royal
-
-	m_aTradeGroups.Write(pStream); //R&R mod, vetiarvind, trade groups
+		
+	m_aTradeGroups.Write(pStream); //R&R mod, vetiarvind, trade groups	
 
 	WriteStreamableFFreeListTrashArray(m_selectionGroups, pStream);
 	WriteStreamableFFreeListTrashArray(m_eventsTriggered, pStream);
@@ -14403,7 +14403,7 @@ void CvPlayer::applyEvent(EventTypes eEvent, int iEventTriggeredId, bool bUpdate
 	FAssert(eEvent != NO_EVENT);
 
 	int iGrowthPercent = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getGrowthPercent();
-
+	
 	EventTriggeredData* pTriggeredData = getEventTriggered(iEventTriggeredId);
 
 	if (NULL == pTriggeredData)
@@ -14440,7 +14440,7 @@ void CvPlayer::applyEvent(EventTypes eEvent, int iEventTriggeredId, bool bUpdate
 	int iGold = getEventCost(eEvent, pTriggeredData->m_eOtherPlayer, false);
 	int iRandomGold = getEventCost(eEvent, pTriggeredData->m_eOtherPlayer, true);
 	iGold += GC.getGameINLINE().getSorenRandNum(iRandomGold - iGold + 1, "Event random gold");
-
+	
 	if (iGold != 0)
 	{
 		changeGold(iGold);
@@ -14594,10 +14594,10 @@ void CvPlayer::applyEvent(EventTypes eEvent, int iEventTriggeredId, bool bUpdate
 			int iCulture = kEvent.getCulture();
 			iCulture *= iGrowthPercent;
 			iCulture /= 100;
-
+			
 			for (CvCity* pLoopCity = firstCity(&iLoop); NULL != pLoopCity; pLoopCity = nextCity(&iLoop))
 			{
-
+				
 				if (pLoopCity->getCulture(pLoopCity->getOwnerINLINE()) + iCulture > 0)
 				{
 					pLoopCity->changeCulture(pLoopCity->getOwnerINLINE(), iCulture, true);
@@ -15906,7 +15906,7 @@ void CvPlayer::setYieldBuyPrice(YieldTypes eYield, int iPrice, bool bMessage)
 									eYield = YIELD_RED_PEPPER;
 									iPrice = getYieldBuyPrice(YIELD_RED_PEPPER) - 1;
 								}
-								break;
+								break;	
 							case YIELD_BEER:
 								if (getYieldBuyPrice(eYield) - getYieldBuyPrice(YIELD_BARLEY) <= price_diff)
 								{
@@ -16041,10 +16041,10 @@ void CvPlayer::sellYieldUnitToEurope(CvUnit* pUnit, int iAmount, int iCommission
 					{
 						CvPlayer& kPlayerEurope = GET_PLAYER(getParent());
 						int price = kPlayerEurope.getYieldBuyPrice(eYield);
-						iProfit = iAmount * price  * (100 - iBribe) / 100;
+						iProfit = iAmount * price  * (100 - iBribe) / 100;						
 						iSellPrice = price; // R&R, vetiarvind, Price dependent tax rate change
 					}
-
+					
 				}
 				else
 				{
@@ -16053,15 +16053,15 @@ void CvPlayer::sellYieldUnitToEurope(CvUnit* pUnit, int iAmount, int iCommission
 				}
 				// R&R, ray, Smuggling - END
 				changeGold(iProfit * getExtraTradeMultiplier(kPlayerEurope.getID()) / 100);
-
+				
 				// R&R, vetiarvind, Price dependent tax rate change - Start
 				//changeYieldTradedTotal(eYield, iAmount);
-				//kPlayerEurope.changeYieldTradedTotal(eYield, iAmount);
+				//kPlayerEurope.changeYieldTradedTotal(eYield, iAmount);				
 				changeYieldTradedTotal(eYield, iAmount, iSellPrice);
 				kPlayerEurope.changeYieldTradedTotal(eYield, iAmount, iSellPrice);
-
+				
 				// R&R, vetiarvind, Price dependent tax rate change - End
-
+				
 				GC.getGameINLINE().changeYieldBoughtTotal(kPlayerEurope.getID(), eYield, -iAmount);
 
 				pUnit->setYieldStored(pUnit->getYieldStored() - iAmount);
@@ -16427,7 +16427,7 @@ void CvPlayer::setYieldAfricaBuyPrice(YieldTypes eYield, int iPrice, bool bMessa
 									eYield = YIELD_RED_PEPPER;
 									iPrice = getYieldAfricaBuyPrice(YIELD_RED_PEPPER) - 1;
 								}
-								break;
+								break;	
 							case YIELD_BEER:
 								if (getYieldAfricaBuyPrice(eYield) - getYieldAfricaBuyPrice(YIELD_BARLEY) <= price_diff)
 								{
@@ -16582,7 +16582,7 @@ CvUnit* CvPlayer::buyYieldUnitFromAfrica(YieldTypes eYield, int iAmount, CvUnit*
 		kPlayerEurope.changeYieldTradedTotal(eYield, iAmount, iBuyValue);
 		//changeYieldTradedTotal(eYield, iAmount);
 		//kPlayerEurope.changeYieldTradedTotal(eYield, iAmount);
-		// R&R, vetiarvind, Price dependent tax rate change - End
+		// R&R, vetiarvind, Price dependent tax rate change - End		
 		GC.getGameINLINE().changeYieldBoughtTotal(kPlayerEurope.getID(), eYield, iAmount);
 
 		CvWStringBuffer szMessage;
@@ -16668,13 +16668,13 @@ void CvPlayer::sellYieldUnitToAfrica(CvUnit* pUnit, int iAmount, int iCommission
 				}
 				// R&R, ray, Smuggling - END
 				changeGold(iProfit * getExtraTradeMultiplier(kPlayerEurope.getID()) / 100);
-				// R&R, vetiarvind, Price dependent tax rate change - Start
+				// R&R, vetiarvind, Price dependent tax rate change - Start				
 				changeYieldTradedTotal(eYield, iAmount, iSellPrice);
 				kPlayerEurope.changeYieldTradedTotal(eYield, iAmount, iSellPrice);
 				//changeYieldTradedTotal(eYield, iAmount);
 				//kPlayerEurope.changeYieldTradedTotal(eYield, iAmount);
 				// R&R, vetiarvind, Price dependent tax rate change - End
-
+				
 				GC.getGameINLINE().changeYieldBoughtTotal(kPlayerEurope.getID(), eYield, -iAmount);
 
 				pUnit->setYieldStored(pUnit->getYieldStored() - iAmount);
@@ -17131,8 +17131,8 @@ void CvPlayer::sellYieldUnitToPortRoyal(CvUnit* pUnit, int iAmount, int iCommiss
 				}
 				// R&R, ray, Smuggling - END
 				changeGold(iProfit * getExtraTradeMultiplier(kPlayerEurope.getID()) / 100);
-
-				// R&R, vetiarvind, Price dependent tax rate change - Start
+				
+				// R&R, vetiarvind, Price dependent tax rate change - Start				
 				changeYieldTradedTotal(eYield, iAmount, iSellPrice);
 				kPlayerEurope.changeYieldTradedTotal(eYield, iAmount, iSellPrice);
 				//changeYieldTradedTotal(eYield, iAmount);
@@ -17341,7 +17341,7 @@ CvUnit* CvPlayer::buyAfricaUnit(UnitTypes eUnit, int iPriceModifier)
 		gDLL->getInterfaceIFace()->setDirty(AfricaScreen_DIRTY_BIT, true);
 		return NULL;
 	}
-
+	
 	CvUnit* pUnit = NULL;
 	CvPlot* pStartingPlot = getStartingPlot();
 	if (GC.getUnitInfo(eUnit).getDomainType() == DOMAIN_SEA && pStartingPlot != NULL)
@@ -17432,7 +17432,7 @@ CvUnit* CvPlayer::buyPortRoyalUnit(UnitTypes eUnit, int iPriceModifier)
 		gDLL->getInterfaceIFace()->setDirty(PortRoyalScreen_DIRTY_BIT, true);
 		return NULL;
 	}
-
+	
 	CvUnit* pUnit = NULL;
 	CvPlot* pStartingPlot = getStartingPlot();
 	if (GC.getUnitInfo(eUnit).getDomainType() == DOMAIN_SEA && pStartingPlot != NULL)
@@ -17525,25 +17525,25 @@ int CvPlayer::getYieldScoreTotal(YieldTypes eYield) const
 void CvPlayer::setYieldScoreTotal(YieldTypes eYield, int iValue)
 {
 	FAssert(eYield >= 0);
-	FAssert(eYield < NUM_YIELD_TYPES);
+	FAssert(eYield < NUM_YIELD_TYPES);	
 
 	m_aiYieldScoreTotal[eYield] = iValue;
-
+	
 }
 
 void CvPlayer::changeYieldTradedTotal(YieldTypes eYield, int iChange, int iUnitPrice)
 {
 	if(iUnitPrice == -1)	//default parameter declared in header
-	{
-			iUnitPrice = 10;//default score functionality
+	{		
+			iUnitPrice = 10;//default score functionality 
 			if (getParent() != NO_PLAYER)
 			{
-				CvPlayer& kEurope = GET_PLAYER(getParent());
+				CvPlayer& kEurope = GET_PLAYER(getParent());		
 				if (kEurope.isEurope())
-					iUnitPrice = kEurope.getYieldBuyPrice(eYield);
-			}
+					iUnitPrice = kEurope.getYieldBuyPrice(eYield); 
+			}		
 	}
-
+	
 	double iMultiplier = iUnitPrice*0.1;
 	setYieldScoreTotal(eYield, getYieldScoreTotal(eYield) + (int)(iChange*iMultiplier));
 	setYieldTradedTotal(eYield, getYieldTradedTotal(eYield) + iChange);
@@ -17657,7 +17657,7 @@ void CvPlayer::changeTaxRate(int iChange)
 		for(int i=0;i<NUM_YIELD_TYPES;i++)
 		{
 			setYieldTradedTotal((YieldTypes) i, 0);
-			setYieldScoreTotal((YieldTypes) i, 0);// R&R, vetiarvind, price dependent tax rate change
+			setYieldScoreTotal((YieldTypes) i, 0);// R&R, vetiarvind, price dependent tax rate change						 
 		}
 
 		PlayerTypes eParent = getParent();
@@ -18400,7 +18400,7 @@ void CvPlayer::doPrices()
 		{
 			if (getHighestTradedYield() != NO_YIELD)
 			{
-				// R&R, vetiarvind, Price dependent tax rate change - START
+				// R&R, vetiarvind, Price dependent tax rate change - START				
 				/*
 				int iTotalTraded = 0;
 				for (int i = 0; i < NUM_YIELD_TYPES; i++)
@@ -18410,7 +18410,7 @@ void CvPlayer::doPrices()
 						iTotalTraded += getYieldTradedTotal((YieldTypes) i);
 					}
 				}*/
-				int iTotalScore = 0;
+				int iTotalScore = 0; 
 				for (int i = 0; i < NUM_YIELD_TYPES; i++)
 				{
 					if (isYieldEuropeTradable((YieldTypes)i))
@@ -18437,11 +18437,11 @@ void CvPlayer::doPrices()
 
 				// R&R, vetiarvind, Price dependent tax rate change - START
 				//if (iTotalTraded * 10000 > GC.getTAX_TRADE_THRESHOLD() * std::max(100, iMultiplier) * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getGrowthPercent())
-
+				
 				//compare total traded with trade threshold
-				if (iTotalScore * 10000 > GC.getTAX_TRADE_THRESHOLD() * std::max(100, iMultiplier) * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getGrowthPercent())
+				if (iTotalScore * 10000 > GC.getTAX_TRADE_THRESHOLD() * std::max(100, iMultiplier) * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getGrowthPercent())								
 				{
-					// R&R, vetiarvind, Price dependent tax rate change - END
+					// R&R, vetiarvind, Price dependent tax rate change - END				
 					//random chance to raise tax rate
 					// R&R, ray, Improvements to Tax Mechanism - START
 					int iTaxIncreaseChanceModifierFromKingAttitude = GET_PLAYER(eParent).AI_getAttitudeVal(getID()) * GC.getTAX_TRADE_INCREASE_CHANCE_KING_ATTITUDE_BASE();
@@ -19283,7 +19283,7 @@ bool CvPlayer::checkPopulation() const
 		}
 	}
 	/**************************************/
-
+	
 	// R&R, ray, Port Royal
 	for (uint i = 0; i < m_aPortRoyalUnits.size(); ++i)
 	{
@@ -19326,7 +19326,7 @@ bool CvPlayer::checkPower(bool bReset)
 		iAsset += m_aAfricaUnits[i]->getAsset();
 	}
 	/**************************************/
-
+	
 	// R&R, ray, Port Royal
 	for (uint i = 0; i < m_aPortRoyalUnits.size(); ++i)
 	{
@@ -19698,7 +19698,7 @@ void CvPlayer::doAchievements(bool afterMove)
 									{
 										check = true;
 									}
-								}
+								}			
 
 //								if (pCity->isHasSpecialBuilding(GC.getBuildingInfo((BuildingTypes)iK).getSpecialBuildingType()))
 //								if (pCity->isHasBuilding((BuildingTypes)iK))
@@ -20415,15 +20415,15 @@ void CvPlayer::checkForNativeSlaves()
 					discount = 50;
 				}
 				int totalslaveprice = baseslaveprice - discount;
-
+				
 				//Gamespeed
 				int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
 
 				totalslaveprice = totalslaveprice * gamespeedMod / 100;
-
+				
 				//simple logik for AI
 				if (!isHuman())
-				{
+				{			
 					CvPlayerAI& kPlayerAI = GET_PLAYER((PlayerTypes) getID());
 					// TAC - AI Military Buildup - koma13
 					if (!kPlayerAI.AI_isStrategy(STRATEGY_MILITARY_BUILDUP))
@@ -20518,7 +20518,7 @@ void CvPlayer::checkForAfricanSlaves()
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
 	//for safety
 	if (locationToAppear == NULL)
@@ -20609,7 +20609,7 @@ void CvPlayer::checkForPrisonsCrowded()
 		return;
 	}
     int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
-
+	
 	//check if min round for feature activation has been reached
 	if(GC.getGame().getGameTurn() < GC.getMIN_ROUND_PRISONS_CROWDED()*gamespeedMod/100)
 	{
@@ -20626,7 +20626,7 @@ void CvPlayer::checkForPrisonsCrowded()
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
     //for safety
 	if (locationToAppear == NULL)
@@ -20735,7 +20735,7 @@ void CvPlayer::checkForRevolutionaryNoble()
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
     //for safety
 	if (locationToAppear == NULL)
@@ -20854,7 +20854,7 @@ void CvPlayer::checkForBishop()
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
     //for safety
 	if (locationToAppear == NULL)
@@ -20938,7 +20938,7 @@ void CvPlayer::buyNativeMercs(PlayerTypes sellingPlayer, int price, bool mightbe
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
 	//for safety stop if no city
 	// R&R, ray safe mechanism to ensure that player gold never is negative
@@ -20994,7 +20994,7 @@ void CvPlayer::checkForRevolutionSupport()
 		{
 			locationToAppear = pLoopCity;
 			break;
-		}
+		}			
 	}
 
 	//for safety stop if no city
@@ -21013,7 +21013,7 @@ void CvPlayer::checkForRevolutionSupport()
 		{
 			// Erik: We also require that the player is on good terms with the potential supporter's king
 			if (potentialRevSupporter.getParent() != NO_PLAYER && GET_PLAYER(potentialRevSupporter.getParent()).AI_getAttitude(getID(), false) >= GC.getDefineINT("MIN_ATTITUDE_FOR_SUPPORT"))
-			{
+			{ 
 				//checking random chance for merc
 				int randomSupportValue = GC.getGameINLINE().getSorenRandNum(1000, "Rev Support");
 				int supportChance = GC.getDefineINT("BASE_CHANCE_FOR_SUPPORT");
@@ -21115,7 +21115,7 @@ void CvPlayer::checkForEuropeanWars()
 		{
 			locationToAppear = pLoopCity;
 			break;
-		}
+		}			
 	}
 
 	//for safety stop if no city
@@ -21213,7 +21213,7 @@ void CvPlayer::checkForStealingImmigrant()
 
 	// get price
 	int priceStealingImmigrant = GC.getDefineINT("BASE_STEALING_IMMIGRANT_PRICE");
-
+	
 	priceStealingImmigrant = priceStealingImmigrant * gamespeedMod / 100;
 
 	// simple case for AI
@@ -21279,7 +21279,7 @@ void CvPlayer::checkForStealingImmigrant()
 		{
 			pDiplo->setDiploComment((DiploCommentTypes)GC.getInfoTypeForString("AI_DIPLOCOMMENT_STEALING_IMMIGRANT_CANT_AFFORD"));
 		}
-
+	
 		pDiplo->addDiploCommentVariable(GC.getCivilizationInfo(GET_PLAYER(potentialVictim.getParent()).getCivilizationType()).getShortDescriptionKey()); //getting Parent of Enemy for text
 		pDiplo->addDiploCommentVariable(priceStealingImmigrant); // price for text
 
@@ -21288,7 +21288,7 @@ void CvPlayer::checkForStealingImmigrant()
 		pDiplo->setData(potentialVictim.getID());
 
 		pDiplo->setAIContact(true);
-		gDLL->beginDiplomacy(pDiplo, getID());
+		gDLL->beginDiplomacy(pDiplo, getID());		
 	}
 
 	return;
@@ -21356,7 +21356,7 @@ void CvPlayer::checkForSmugglers()
 		{
 			locationToAppear = pLoopCity;
 			break;
-		}
+		}			
 	}
 
 	if (locationToAppear == NULL)
@@ -21399,7 +21399,7 @@ void CvPlayer::checkForSmugglers()
 
 // R&R, ray, Rangers - START
 void CvPlayer::checkForRangers()
-{
+{	
 	// not in Revolution
 	if(isInRevolution())
 	{
@@ -21444,11 +21444,11 @@ void CvPlayer::checkForRangers()
 	}
 
 	int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
-
+    
 
 
 	int pricetopay = GC.getDefineINT("PRICE_RANGERS") * gamespeedMod / 100;
-
+	
 	// simple logic for AI
 	if (!isHuman())
 	{
@@ -21495,7 +21495,7 @@ void CvPlayer::checkForRangers()
 
 // R&R, ray, Conquistadors - START
 void CvPlayer::checkForConquistadors()
-{
+{	
 	// not in Revolution
 	if(isInRevolution())
 	{
@@ -21520,7 +21520,7 @@ void CvPlayer::checkForConquistadors()
 		{
 			hasWarWithNatives = true;
 			break;
-		}
+		}	
 	}
 
 	if (!hasWarWithNatives)
@@ -21565,17 +21565,17 @@ void CvPlayer::checkForConquistadors()
 		CvPlayerAI& kPlayerAI = GET_PLAYER((PlayerTypes) getID());
 		// TAC - AI Military Buildup - koma13
 		if (!kPlayerAI.AI_isStrategy(STRATEGY_MILITARY_BUILDUP))
-		{
+		{	
 			int iMercRand = GC.getGameINLINE().getSorenRandNum(100, "AI should buy Mercenaries?");
 			if (iMercRand < GC.getDefineINT("AI_CHANCE_FOR_BUYING_MERCENARIES"))
 			{
 				int iMercPriceAI = pricetopay * GC.getDefineINT("AI_PRICE_PERCENT_FOR_BUYING_MERCENARIES") / 100;
 				if (getGold() > iMercPriceAI)
-				{
+				{								
 					m_iTimerConquistador = GC.getTIMER_CONQUISTADOR() * gamespeedMod /100 ;
 					//create the conquistador
 					UnitTypes ConquistadorType;
-					int conquistUnitRand = GC.getGameINLINE().getSorenRandNum(3, "Conquistadors Available");
+					int conquistUnitRand = GC.getGameINLINE().getSorenRandNum(3, "Conquistadors Available");	
 					if (conquistUnitRand == 1)
 					{
 						ConquistadorType = (UnitTypes)GC.getCivilizationInfo(getCivilizationType()).getCivilizationUnits(GC.getDefineINT("UNITCLASS_MOUNTED_CONQUISTADOR"));
@@ -21663,7 +21663,7 @@ void CvPlayer::checkForPirates()
 		{
 			locationToAppear = pLoopCity;
 			break;
-		}
+		}			
 	}
 
 	if (locationToAppear == NULL)
@@ -21743,7 +21743,7 @@ void CvPlayer::checkForEuropeanPeace()
 	}
 
 	int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
-
+    
 	int randomEuropePeaceValue = GC.getGameINLINE().getSorenRandNum(1000, "European Peace");
 	int peaceChance = GC.getBASE_CHANCE_EUROPE_PEACE();
 
@@ -21757,7 +21757,7 @@ void CvPlayer::checkForEuropeanPeace()
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
     //for safety
 	if (locationToAppear == NULL)
@@ -21843,7 +21843,7 @@ bool CvPlayer::tryGetNewBargainPriceBuy()
 	int attitudeLevel = GET_PLAYER(bargainPartner).AI_getAttitude(getID(), false);
 	int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
 	int randomBase = 1000 + attitudeChanceImprovement * attitudeLevel;
-
+	
 	/// random network fix - start - Nightinggale
 	//int randomValue = GC.getGameINLINE().getSorenRandNum(randomBase, "Bargaining Buy");
 	int randomValue = std::rand() % randomBase;
@@ -21929,7 +21929,7 @@ void CvPlayer::createEnemyPirates()
 			if (pLoopPlot->area() != cityToAttack->area())
 			{
 				iValue *= 3;
-			}
+			}	
 			if (iValue < iBestValue)
 			{
 				iBestValue = iValue;
@@ -22016,7 +22016,7 @@ void CvPlayer::checkForContinentalGuard()
 				//continentalGuardDonator = (PlayerTypes) iPlayer;
 				bestvalue = randnum;
 			}
-
+			
 		}
 	}
 
@@ -22133,7 +22133,7 @@ void CvPlayer::checkForMortar()
 				mortarDonator = potentialRevSupporter.getParent();
 				bestvalue = randnum;
 			}
-
+			
 		}
 	}
 
@@ -22199,7 +22199,7 @@ void CvPlayer::checkForMilitiaOrUnrest()
 				{
 					int randomMilitiaValue = GC.getGameINLINE().getSorenRandNum(1000, "Militia Rand");
 					int randomUnrestValue = GC.getGameINLINE().getSorenRandNum(1000, "Unrest Rand");
-
+					
 					if (chanceForMilitia > randomMilitiaValue && getGold() >= pricetopay && pLoopCity->getYieldStored(YIELD_FOOD) > foodQty)
 					{
 						//create the Militia
@@ -22211,11 +22211,11 @@ void CvPlayer::checkForMilitiaOrUnrest()
 						CvWString szBuffer = gDLL->getText("TXT_KEY_CITY_LEVIED_MILITIA_FOR_PROTECTION", pLoopCity->getNameKey());
 						gDLL->getInterfaceIFace()->addMessage(getID(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_DEAL_CANCELLED", MESSAGE_TYPE_MINOR_EVENT, MilitiaUnit->getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_WHITE"), MilitiaUnit->getX(), MilitiaUnit->getY(), true, true);
 					}
-
+	
 					else if(chanceForUnrest > randomUnrestValue)
 					{
 						int unrestTime = (pLoopCity->getPopulation() / 10);
-						if (unrestTime < 2)
+						if (unrestTime < 2) 
 						{
 							unrestTime = 2;
 						}
@@ -22281,7 +22281,7 @@ void CvPlayer::checkForChurchContact()
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
     //for safety
 	if (locationToAppear == NULL)
@@ -22411,14 +22411,14 @@ void CvPlayer::checkForChurchWar()
 	CvCity* pLoopCity = NULL;
 	CvCity* locationToAppear = NULL;
 	int iLoop;
-	locationToAppear = firstCity(&iLoop);
+	locationToAppear = firstCity(&iLoop); 
 
     //for safety
 	if (locationToAppear == NULL)
 	{
 		return;
 	}
-
+	
 
 	// check randoms
 	int randomValue = GC.getGameINLINE().getSorenRandNum(1000, "Church WAR");
@@ -22580,7 +22580,7 @@ bool CvPlayer::isYieldPortRoyalTradable(YieldTypes eYield) const
 {
 	FAssert(eYield >= 0 && eYield < NUM_YIELD_TYPES);
 
-	if (getParent() == NO_PLAYER)
+	if (getParent() == NO_PLAYER) 
 	{
 		return false;
 	}
@@ -22599,7 +22599,7 @@ bool CvPlayer::isYieldPortRoyalTradable(YieldTypes eYield) const
 	{
 		return false;
 	}
-
+	
 	return true; // Port Royal is not under the rule of your king
 	//return m_abYieldEuropeTradable[eYield];
 }
@@ -22632,7 +22632,7 @@ int CvPlayer::addTradeRouteGroup(const std::wstring groupName)
 	for (CvIdVector<CvTradeRouteGroup>::iterator it = m_aTradeGroups.begin(); it != m_aTradeGroups.end(); ++it)
 	{
 		CvTradeRouteGroup* pTradeRouteGroup = it->second;
-		if (pTradeRouteGroup->getName(0).compare(groupName) == 0)
+		if (pTradeRouteGroup->getName(0).compare(groupName) == 0)			
 		{
 			pTradeRouteGroup->clearRoutes();
 			return pTradeRouteGroup->getID();
@@ -22640,7 +22640,7 @@ int CvPlayer::addTradeRouteGroup(const std::wstring groupName)
 	}
 
 	CvTradeRouteGroup* pTradeRouteGroup = m_aTradeGroups.addNew();
-	pTradeRouteGroup->setName(groupName.c_str());
+	pTradeRouteGroup->setName(groupName.c_str());	
 	if (getID() == GC.getGameINLINE().getActivePlayer())
 	{
 		gDLL->getInterfaceIFace()->setDirty(Domestic_Advisor_DIRTY_BIT, true);
@@ -22658,36 +22658,36 @@ bool CvPlayer::editTradeRouteGroup(int iId, const std::wstring groupName)
 		return false;
 	}
 
-	for (CvIdVector<CvTradeRouteGroup>::iterator it = m_aTradeGroups.begin(); it != m_aTradeGroups.end(); ++it)
+	for (CvIdVector<CvTradeRouteGroup>::iterator it = m_aTradeGroups.begin(); it != m_aTradeGroups.end(); ++it)	
 	{
 		CvTradeRouteGroup* pLoopTradeRouteGroup = it->second;
-		if (pTradeRouteGroup->getName(0).compare(groupName) == 0)
+		if (pTradeRouteGroup->getName(0).compare(groupName) == 0)		
 		{
 			return false;
 		}
 	}
 
-	pTradeRouteGroup->setName(groupName.c_str());
+	pTradeRouteGroup->setName(groupName.c_str());	
 
 	return true;
 }
 
 
 bool CvPlayer::removeTradeRouteGroup(int iId)
-{
-	return m_aTradeGroups.removeById(iId);
+{	
+	return m_aTradeGroups.removeById(iId);	
 }
 
 
 
 CvTradeRouteGroup* CvPlayer::getTradeRouteGroupById(int tradeGroupId) const
-{
+{		
 	return m_aTradeGroups.getById(tradeGroupId);
 }
 
 CvTradeRouteGroup* CvPlayer::getTradeRouteGroup(int iIndex) const
-{
-	FAssert(iIndex >= 0 && iIndex < getNumTradeGroups());
+{		
+	FAssert(iIndex >= 0 && iIndex < getNumTradeGroups());	
 	int i = 0;
 	for (CvIdVector<CvTradeRouteGroup>::const_iterator it = m_aTradeGroups.begin(); it != m_aTradeGroups.end(); ++it)
 	{
@@ -22701,7 +22701,7 @@ CvTradeRouteGroup* CvPlayer::getTradeRouteGroup(int iIndex) const
 }
 
 int CvPlayer::getNumTradeGroups() const
-{
+{	
 	return m_aTradeGroups.size();
 }
 

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -20003,24 +20003,7 @@ bool CvPlayer::LbD_try_become_expert(CvUnit* convUnit, int base, int increase, i
 	if (currentProfession != lastProfession)
 	{
 		convUnit->setLastLbDProfession(currentProfession);
-		if(isHuman())
-		{
-			//workedRounds = 1;
-			convUnit->setLbDrounds(1);
-		}
-		// here little cheat for AI to cope with feature
-		// profession change does not reset worked rounds
-		else
-		{
-			//workedRounds++;
-			convUnit->setLbDrounds(workedRounds + 1);
-		}
-	}
-
-	else
-	{
-		//workedRounds++;
-		convUnit->setLbDrounds(workedRounds + 1);
+		return false;
 	}
 
 	if (workedRounds < pre_rounds)
@@ -20168,12 +20151,31 @@ void CvPlayer::doLbD()
 	//getting GameSpeedModifiert in percent
 	int train_percent = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
 
-	//moddifying Expert values with GameSpeed
-	chance_increase_expert = chance_increase_expert / train_percent / 100;
+	//moddifying values with GameSpeed
+	chance_increase_expert = chance_increase_expert * 100 / train_percent;
 	pre_rounds_expert = pre_rounds_expert * train_percent / 100;
 
-	chance_increase_free = chance_increase_free / train_percent / 100;
+	chance_increase_free = chance_increase_free * 100 /  train_percent ;
+	if(chance_increase_free <= 0) {
+		chance_increase_free = 1;
+	}
+	if (chance_increase_expert <= 0) {
+		chance_increase_expert = 1;
+	}
 	pre_rounds_free = pre_rounds_free * train_percent / 100;
+	for (int iTrait = 0; iTrait < GC.getNumTraitInfos(); ++iTrait)
+	{
+		TraitTypes eTrait = (TraitTypes) iTrait;
+		if (eTrait != NO_TRAIT)
+		{
+			if (hasTrait(eTrait))
+			{
+				pre_rounds_expert *= 100;
+				pre_rounds_expert /= GC.getTraitInfo(eTrait).getLearningByDoingModifier() + 100;
+				
+			}
+		}
+	}
 
 	// loop through units
 	CvUnit* pLoopUnit;
@@ -20413,7 +20415,7 @@ void CvPlayer::checkForNativeSlaves()
 					discount = 50;
 				}
 				int totalslaveprice = baseslaveprice - discount;
-				
+
 				//Gamespeed
 				int gamespeedMod = GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getTrainPercent();
 
@@ -21573,7 +21575,7 @@ void CvPlayer::checkForConquistadors()
 					m_iTimerConquistador = GC.getTIMER_CONQUISTADOR() * gamespeedMod /100 ;
 					//create the conquistador
 					UnitTypes ConquistadorType;
-					int conquistUnitRand = GC.getGameINLINE().getSorenRandNum(3, "Conquistadors Available");	
+					int conquistUnitRand = GC.getGameINLINE().getSorenRandNum(3, "Conquistadors Available");
 					if (conquistUnitRand == 1)
 					{
 						ConquistadorType = (UnitTypes)GC.getCivilizationInfo(getCivilizationType()).getCivilizationUnits(GC.getDefineINT("UNITCLASS_MOUNTED_CONQUISTADOR"));

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,14 @@ Fixes:
 - #40 Worldbuilder issue making very difficult to set diplomatic attitudes fixed.
 - #51 Fixed case where AI could turn stone into lumber (copy paste error)
 - #73 Shipwrecks no longer appear under ice.
+- #77 Learn by Doing system is upgraded:
+        - Now the chance of becoming an expert increases with time.
+        - learn by doing chance is correctly adjusted with game speed.
+        - The overall chance of a unit to become expert is significantly increased,
+          specially for leaders with bonuses to the "chance of becoming expert through hard work".
+        - Changing professions do not reset the Learn by doing count: if only makes the 
+          possibility of an unit to become expert at that turn to be zero.
+        - DOWNSIDE: units may become experts on professions they have recently changed into.
 - #86 The Domestic Advisor: Native tab now allows sorting by the goods the indians want.
 - #87 Hurry production fails if there isn't warehouse space.
 - #96 The Domestic Advisor: native tab now shows natives that you have discovered, but not yet talked with.

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,6 @@ Fixes:
 - #40 Worldbuilder issue making very difficult to set diplomatic attitudes fixed.
 - #51 Fixed case where AI could turn stone into lumber (copy paste error)
 - #73 Shipwrecks no longer appear under ice.
-- #83 It is now possible to change the production at the city plot. Just click at the city center and you can now choose if that city over savannah should build tobacco or sugar...
 - #86 The Domestic Advisor: Native tab now allows sorting by the goods the indians want.
 - #87 Hurry production fails if there isn't warehouse space.
 - #96 The Domestic Advisor: native tab now shows natives that you have discovered, but not yet talked with.


### PR DESCRIPTION
The increase at GlobalDefinesAlt.xml is increased to 5.

Both CvCity and CvPlayer codes have been changed so that:

1) The minimum turns before a unit can become an expert is adjusted
according to traits that confer a bonus to the LbD .

2) The probability of becoming an expert actually increases at each turn
, as it was the original developer's intention.

3) Experience is no longer set to zero if profession changes, allowing colonists to move to different cities or change professions within the cities without losing experience. It only becomes forbidden for a unit to become an expert that turn.

4) Downside: there is a chance that a unit becomes an expert to a profession it only recently changed into.