### PR TITLE
BUGFIX : Defensive units can now get withdraw promotion

### DIFF
--- a/Project Files/DLLSources/CvUnit.cpp
+++ b/Project Files/DLLSources/CvUnit.cpp
@@ -923,7 +923,7 @@ void CvUnit::NotifyEntity(MissionTypes eMission)
 /**                                                                       **/
 /** float CvUnit::NBMOD_GetShipStrength() const                           **/
 /**                                                                       **/
-/** Ermittelt die Schiffst‰rke der Einheit.                               **/
+/** Ermittelt die Schiffst√§rke der Einheit.                               **/
 /**                                                                       **/
 /***************************************************************************/
 
@@ -11902,10 +11902,6 @@ bool CvUnit::isPromotionValid(PromotionTypes ePromotion) const
 		{
 			return false;
 		}
-		if (kPromotion.getWithdrawalChange() != 0)
-		{
-			return false;
-		}
 		if (kPromotion.isBlitz())
 		{
 			return false;
@@ -11935,10 +11931,6 @@ bool CvUnit::isPromotionValid(PromotionTypes ePromotion) const
 			{
 				return false;
 			}
-		}
-		if (kPromotion.getWithdrawalChange() != 0)
-		{
-			return false;
 		}
 	}
 


### PR DESCRIPTION
The original code, inherited from Civ IV, prevented defensive units to get withdrawal promotions .
But we need those for trade naval units at least, for the "Merchant Navy" promotion series.

In RaR or WTP, withdrawal chances represent the ability to flee combat, regardless if the unit is the attacker or the defender. 

I don't think this changes will hurt.