### PR TITLE
Fix for memory access violation

### DIFF
--- a/Project Files/DLLSources/CvCity.cpp
+++ b/Project Files/DLLSources/CvCity.cpp
@@ -11527,20 +11527,20 @@ void CvCity::doLbD()
 			}
 
 			// try to become free if poosible
-			if(pLoopUnit->getUnitInfo().LbD_canGetFree() && !lbd_expert_successful)
+			if(!lbd_expert_successful && pLoopUnit->getUnitInfo().LbD_canGetFree())
 			{
 				lbd_free_successful = LbD_try_get_free(pLoopUnit, base_chance_free, chance_increase_free, pre_rounds_free, mod_free_criminal, mod_free_servant, learn_level);
 			}
 
 			// try to escape if free unsuccesful and escape possible
-			if(pLoopUnit->getUnitInfo().LbD_canEscape() && !lbd_free_successful && !lbd_expert_successful)
+			if(!lbd_free_successful && !lbd_expert_successful && pLoopUnit->getUnitInfo().LbD_canEscape())
 			{
 				lbd_escape_successful = LbD_try_escape(pLoopUnit, base_chance_escape, mod_escape_criminal, mod_escape_servant);
 			}
 
 			// WTP, ray, LbD Slaves Revolt and Free - START
 			// try to revolt if escape revolt possible and free unsuccessful and escape unsuccessufl
-			if(pLoopUnit->getUnitInfo().LbD_canRevolt() && !lbd_escape_successful && !lbd_free_successful && !lbd_expert_successful)
+			if(!lbd_escape_successful && !lbd_free_successful && !lbd_expert_successful && pLoopUnit->getUnitInfo().LbD_canRevolt())
 			{
 				lbd_revolt_successful = LbD_try_revolt(pLoopUnit, base_chance_revolt, mod_revolt_criminal, mod_revolt_slave);
 			}

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -4975,10 +4975,6 @@ void CvPlayer::disband(CvCity* pCity, bool bAbandon)
 		setFoundedFirstCity(false);
 	}
 
-
-	pCity->kill();
-
-
 	// Early exit in case the city was razed
 	if (!bAbandon)
 	{
@@ -4987,14 +4983,15 @@ void CvPlayer::disband(CvCity* pCity, bool bAbandon)
 	}
 
 	CvPlot* const pCityPlot = pCity->plot();
+	const PlayerTypes eCityOwner = pCity->getOwnerINLINE();
 	
+	pCity->kill();
+
 	// No ruins for a city that was voluntarily abandoned
 	pCityPlot->setImprovementType(NO_IMPROVEMENT);
 
 	// Loop through all the plots of the city and subtract the free culture that the city itself added.
 	// Culture added by buildings will be kept
-
-	const PlayerTypes eCityOwner = pCity->getOwnerINLINE();
 
 	// TODO: What about civs that get free culture producing buildings?
 	if (pCityPlot->getCulture(eCityOwner) >= GC.getDefineINT("FREE_CITY_CULTURE"))
@@ -5016,7 +5013,6 @@ void CvPlayer::disband(CvCity* pCity, bool bAbandon)
 			}
 		}
 	}
-
 
 	if (pCityPlot->getOwner() == NO_PLAYER)
 	{


### PR DESCRIPTION
getUnitInfo() gets uninitialized data since the unit was destroyed previously if any of the other conditions triggered. Thus, getUnitInfo dependent checks must be performed last, not first.