### PR TITLE
Allow to lock a colonist by choosing the same profession

### DIFF
--- a/Project Files/DLLSources/CvDLLButtonPopup.cpp
+++ b/Project Files/DLLSources/CvDLLButtonPopup.cpp
@@ -2783,7 +2783,7 @@ bool CvDLLButtonPopup::launchChooseProfessionPopup(CvPopup* pPopup, CvPopupInfo 
 		// we want to give ability to "lock" colonist to the current profession by
 		// choosing the same profession as he already does. Only if colonist is currently employed in the city: working the plot, or working in the building
 		// Otherwise, do not allow to change profession to the same profession
-		if ((iProfession == pUnit->getProfession() && (pWorkingPlot != NULL && eWorkingBuilding != NO_BUILDING)) ||
+		if ((iProfession == pUnit->getProfession() && (pWorkingPlot != NULL || eWorkingBuilding != NO_BUILDING)) ||
 			(iProfession != pUnit->getProfession() || bShowOnlyPlotCitizens || bShowOnlyBuildingCitizens) && pUnit->canHaveProfession(eLoopProfession, false))
 		//Androrc End
 		{

--- a/Project Files/DLLSources/CvDLLButtonPopup.cpp
+++ b/Project Files/DLLSources/CvDLLButtonPopup.cpp
@@ -2780,8 +2780,11 @@ bool CvDLLButtonPopup::launchChooseProfessionPopup(CvPopup* pPopup, CvPopupInfo 
 		CvProfessionInfo& kProfession = GC.getProfessionInfo(eLoopProfession);
 
 		//Androrc Multiple Professions per Building
-//		if ((iProfession != pUnit->getProfession() || bShowOnlyPlotCitizens) && pUnit->canHaveProfession(eLoopProfession, false))
-		if ((iProfession != pUnit->getProfession() || bShowOnlyPlotCitizens || bShowOnlyBuildingCitizens) && pUnit->canHaveProfession(eLoopProfession, false))
+		// we want to give ability to "lock" colonist to the current profession by
+		// choosing the same profession as he already does. Only if colonist is currently employed in the city: working the plot, or working in the building
+		// Otherwise, do not allow to change profession to the same profession
+		if ((iProfession == pUnit->getProfession() && (pWorkingPlot != NULL && eWorkingBuilding != NO_BUILDING)) ||
+			(iProfession != pUnit->getProfession() || bShowOnlyPlotCitizens || bShowOnlyBuildingCitizens) && pUnit->canHaveProfession(eLoopProfession, false))
 		//Androrc End
 		{
 			//inside or outside city

--- a/Project Files/DLLSources/CvUnit.cpp
+++ b/Project Files/DLLSources/CvUnit.cpp
@@ -11476,61 +11476,58 @@ bool CvUnit::setProfession(ProfessionTypes eProfession, bool bForce, bool bRemov
 		return false;
 	}
 
-	if (getProfession() != eProfession)
+	if (getProfession() != NO_PROFESSION)
 	{
-		if (getProfession() != NO_PROFESSION)
+		if (GC.getProfessionInfo(getProfession()).isCitizen())
 		{
-			if (GC.getProfessionInfo(getProfession()).isCitizen())
-			{
-				AI_setOldProfession(getProfession());
-			}
+			AI_setOldProfession(getProfession());
 		}
-		if (isOnMap() && eProfession != NO_PROFESSION && GC.getProfessionInfo(eProfession).isCitizen())
-		{
-			CvCity* pCity = plot()->getPlotCity();
-			if (pCity != NULL)
-			{
-				if (canJoinCity(plot()))
-				{
-					pCity->addPopulationUnit(this, eProfession);
-					bool bLock = true;
-					if (GC.getProfessionInfo(eProfession).isWorkPlot())
-					{
-						int iPlotIndex = pCity->AI_bestProfessionPlot(eProfession, this);
-						if (iPlotIndex != -1)
-						{
-							pCity->alterUnitWorkingPlot(iPlotIndex, getID(), false);
-						}
-						else
-						{
-							bLock = false;
-						}
-					}
-
-					setColonistLocked(bLock);
-					return true;
-				}
-			}
-		}
-
-		// clean up from old profession
-		processProfession(getProfession(), -1, false, bRemoveYieldsFromCity);
-		ProfessionTypes eOldProfession = getProfession();
-
-		// actually change profession
-		m_eProfession = eProfession;
-
-		if (getProfessionUnitCombatType(eOldProfession) != getProfessionUnitCombatType(getProfession()))
-		{
-			// set cached data from promotions
-			setPromotions();
-		}
-		processProfession(getProfession(), 1, true, bRemoveYieldsFromCity);
-
-		//reload unit model
-		reloadEntity();
-		gDLL->getInterfaceIFace()->setDirty(Domestic_Advisor_DIRTY_BIT, true);
 	}
+	if (isOnMap() && eProfession != NO_PROFESSION && GC.getProfessionInfo(eProfession).isCitizen())
+	{
+		CvCity* pCity = plot()->getPlotCity();
+		if (pCity != NULL)
+		{
+			if (canJoinCity(plot()))
+			{
+				pCity->addPopulationUnit(this, eProfession);
+				bool bLock = true;
+				if (GC.getProfessionInfo(eProfession).isWorkPlot())
+				{
+					int iPlotIndex = pCity->AI_bestProfessionPlot(eProfession, this);
+					if (iPlotIndex != -1)
+					{
+						pCity->alterUnitWorkingPlot(iPlotIndex, getID(), false);
+					}
+					else
+					{
+						bLock = false;
+					}
+				}
+
+				setColonistLocked(bLock);
+				return true;
+			}
+		}
+	}
+
+	// clean up from old profession
+	processProfession(getProfession(), -1, false, bRemoveYieldsFromCity);
+	ProfessionTypes eOldProfession = getProfession();
+
+	// actually change profession
+	m_eProfession = eProfession;
+
+	if (getProfessionUnitCombatType(eOldProfession) != getProfessionUnitCombatType(getProfession()))
+	{
+		// set cached data from promotions
+		setPromotions();
+	}
+	processProfession(getProfession(), 1, true, bRemoveYieldsFromCity);
+
+	//reload unit model
+	reloadEntity();
+	gDLL->getInterfaceIFace()->setDirty(Domestic_Advisor_DIRTY_BIT, true);
 
 	if (eProfession != NO_PROFESSION)
 	{


### PR DESCRIPTION
My use-case is following:
1) There are a bunch of automated citizens in the city
2) There is a blacksmith shop, and a blacksmith B1 is working there (along with other colonists)
3) B1 is automated, and was chosen to work as a blacksmith making tools
4) I want to lock B1 to being blacksmith (so that any changes to availability of ore, or available space in storage, do not affect his job)

Right now, in order to lock B1 as a blacksmith, I have to do:
1) move him to another plot or building, and choose his profession. This way he is locked as another profession.
2) or change his current profession in the current building - make him a Bladesmith.
3) or automate him by moving him out of the city and settling in the city again.

Only then I can move him to the blacksmith shop, assign him a profession of Blacksmith, and lock him at that.

The following changes allow me to lock the colonist's profession by choosing the profession he is working currently, saving a bunch of clicks. 

I only allow this option, if colonist is working on the city's plot, or if he is working in the city's building. So colonists in the city, but not working in the city (settler outside of city, but on the city square), cannot choose the same profession. Also, if colonist is in Europe/Africa/Pirates, the option is not there.

Screenshot when 3rd blacksmith is clicked on in the Ironworks after the change:
![blacksmith-after](https://user-images.githubusercontent.com/79237/184449377-394da026-8877-460c-8a7c-dc71f9763dbd.png)
Screenshot before the change:
![blacksmith-before](https://user-images.githubusercontent.com/79237/184449603-8f33c384-460e-4b17-b6c5-9c88b3ac1b8d.png)


