### PR TITLE
Correct number of turn in paths with new movement system [3]

### DIFF
--- a/Project Files/DLLSources/CvGameCoreUtils.cpp
+++ b/Project Files/DLLSources/CvGameCoreUtils.cpp
@@ -1771,7 +1771,7 @@ int pathAdd(FAStarNode* parent, FAStarNode* node, int data, const void* pointer,
 	// K-Mod end
 	FAssert(pSelectionGroup->getNumUnits() > 0);
 
-	int iTurns = GLOBAL_DEFINE_USE_CLASSIC_MOVEMENT_SYSTEM;
+	int iTurns = 1;
 	int iMoves = MAX_INT;
 	const bool bMoveMaxMoves = (iFlags & MOVE_MAX_MOVES);
 


### PR DESCRIPTION
Sorry, it should still start counting with 1 and not with 0 (for NMS) ...