### PR TITLE
Change some AI logic & make AI a little easier to kill

### DIFF
--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -24829,7 +24829,9 @@ namespace
 		// Erik: Sort the units by the absolute value
 		// since some units may have a negative cost
 		// to signify that they cannot be purchased
-		return abs(pUnitA->getUnitInfo().getEuropeCost()) > abs(pUnitB->getUnitInfo().getEuropeCost());
+		const int iUnitValueA = pUnitA->canFound(NULL) ? INT_MAX : abs(pUnitA->getUnitInfo().getEuropeCost());
+		const int iUnitValueB = pUnitB->canFound(NULL) ? INT_MAX : abs(pUnitB->getUnitInfo().getEuropeCost());
+		return iUnitValueA > iUnitValueB;
 	}
 }
 

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -8382,7 +8382,8 @@ void CvPlayer::verifyAlive()
 				// TAC - RESPAWN Option - Ray - Start
 				// WTP, ray, fix for Colonial AI not being possible to eliminate a Colonial AI - Check for "No more Settler" removed because causing Problems with Settler is Europe
 				// Added veto check for having at least a single settler
-				if (!isNative() && !isHuman() && GC.getGameINLINE().getGameTurn() > iMinTurnForAIRespawningOff && GC.getDefineINT("KI_RESPAWN_OFF") == 1 && AI_getNumAIUnits(UNITAI_SETTLER) == 0 && (getNumUnits() < 5 || AI_getNumAIUnits(UNITAI_TRANSPORT_SEA) == 0))
+				// only count units which are not treasures (because AI usually has a lot of them stuck somewhere on the map and they are useless if a player has nothing else left)
+				if (!isNative() && !isHuman() && GC.getGameINLINE().getGameTurn() > iMinTurnForAIRespawningOff && GC.getDefineINT("KI_RESPAWN_OFF") == 1 && AI_getNumAIUnits(UNITAI_SETTLER) == 0 && ((getNumUnits() - AI_getNumAIUnits(UNITAI_TREASURE)) < 5 || AI_getNumAIUnits(UNITAI_TRANSPORT_SEA) == 0))
 				{
 					bKill = true;
 					bRespawnDeactivated = true;

--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -6549,37 +6549,41 @@ bool CvUnitAI::AI_europe()
 		kOwner.AI_doEurope();
 	}
 	
+	if (!kOwner.getNumCities() == 0)
+	{	// only do this if we have not lost all our cities!
+		// Otherwise we'll get our transport units stuck in a loop to Europe and back
 	// TAC - AI purchases military units - koma13 - START
-	for (int i = 0; i < kOwner.getNumEuropeUnits(); ++i)
-	{
-		CvUnit* pLoopUnit = kOwner.getEuropeUnit(i);
-		if (!isFull() && pLoopUnit->canAttack())
+		for (int i = 0; i < kOwner.getNumEuropeUnits(); ++i)
 		{
-			if (pLoopUnit->canLoadUnit(this, plot(), false))
+			CvUnit* pLoopUnit = kOwner.getEuropeUnit(i);
+			if (!isFull() && pLoopUnit->canAttack())
 			{
-				bool bLoadUnit = (GET_TEAM(getTeam()).getAnyWarPlanCount() > 0) ? true : false;
-
-				if (!bLoadUnit && (pLoopUnit->AI_getUnitAIType() == UNITAI_DEFENSIVE))
+				if (pLoopUnit->canLoadUnit(this, plot(), false))
 				{
-					int iUndefended = 0;
-					int iNeeded = kOwner.AI_totalDefendersNeeded(&iUndefended);
-					
-					if (iUndefended > 0)
+					bool bLoadUnit = (GET_TEAM(getTeam()).getAnyWarPlanCount() > 0) ? true : false;
+
+					if (!bLoadUnit && (pLoopUnit->AI_getUnitAIType() == UNITAI_DEFENSIVE))
 					{
-						if (GC.getGameINLINE().getSorenRandNum(100, "AI load military unit?") < 50)
+						int iUndefended = 0;
+						int iNeeded = kOwner.AI_totalDefendersNeeded(&iUndefended);
+					
+						if (iUndefended > 0)
 						{
-							bLoadUnit = true;
+							if (GC.getGameINLINE().getSorenRandNum(100, "AI load military unit?") < 50)
+							{
+								bLoadUnit = true;
+							}
 						}
 					}
-				}
 							
-				if (bLoadUnit)
-				{
-					kOwner.loadUnitFromEurope(pLoopUnit, this);
-					if (getGroup()->getAutomateType() == AUTOMATE_FULL)
+					if (bLoadUnit)
 					{
-						FAssert(pLoopUnit->getGroup() != NULL);
-						pLoopUnit->getGroup()->setAutomateType(AUTOMATE_FULL);
+						kOwner.loadUnitFromEurope(pLoopUnit, this);
+						if (getGroup()->getAutomateType() == AUTOMATE_FULL)
+						{
+							FAssert(pLoopUnit->getGroup() != NULL);
+							pLoopUnit->getGroup()->setAutomateType(AUTOMATE_FULL);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This patch will:
1) improve AI load order in Europe so it always loads settlers first
2) fix the endless loop after the last AI settlement has been conquered, where AI transports would loop to Europe to get settlers but fail to load them, travel back to America and then to Europe again.
3) change the number of units for a player to survive from 5 total to 5 excluding treasures, thereby making AI a little easier to kill