### PR TITLE
Modified faireweather for more realistic desert/barren landscapes

### DIFF
--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -4976,7 +4976,7 @@ def generateShrubland():
             plot = mmap.plot(x,y)
             if not plot.getPlotType() == PlotTypes.PLOT_PEAK: #and (plot.isRiver() and not isAnyAdjacentPlotTerrainType(x, y, terrainDesert)):
                 if plot.getTerrainType() == terrainPrairie or plot.getTerrainType() == terrainPlains or plot.getTerrainType() == terrainGrassland:
-                    if (isAnyAdjacentPlotTerrainType(x, y, terrainDesert) or isAnyAdjacentPlotTerrainType(x, y, terrainPlains) or isAnyAdjacentPlotTerrainType(x, y, terrainPrairie)) and (sm.rainFallMap[GetIndex(x, y)] < 0.0035 and sm.rainFallMap[GetIndex(x, y)] > 0.002 and sm.averageTempMap[GetIndex(x, y)] > 0.55):
+                    if isAnyAdjacentPlotTerrainType(x, y, terrainDesert) or (isAnyAdjacentPlotTerrainType(x, y, terrainPlains) or isAnyAdjacentPlotTerrainType(x, y, terrainPrairie)) and (sm.rainFallMap[GetIndex(x, y)] < 0.0035 and sm.rainFallMap[GetIndex(x, y)] > 0.002 and sm.averageTempMap[GetIndex(x, y)] > 0.55):
                         if PRand.random() <= shrublandChance:
                             plot.setTerrainType(terrainShrubland, True, True)
                             iRandPlotType = PRand.random()

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -115,7 +115,7 @@ class MapConstants :
         #How many map squares will be below desert rainfall threshold. In this case,
         #rain levels close to zero are very likely to be desert, while rain levels close
         #to the desert threshold will more likely be plains.
-        self.DesertPercent = 0.05
+        self.DesertPercent = 0.065
 
         #How many map squares will be below plains rainfall threshold. Rain levels close
         #to the desert threshold are likely to be plains, while those close to the plains

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -2037,6 +2037,7 @@ class SmallMaps :
         
         return
     def createTerrainMap(self):
+	mcDup = ClimateMap()
         self.terrainMap = array('i')
         #initialize terrainMap with OCEAN
         for i in range(0,mc.height*mc.width):
@@ -2053,6 +2054,7 @@ class SmallMaps :
         self.plainsThreshold = FindValueFromPercent(self.rainFallMap,mc.width,mc.height,mc.PlainsPercent,.0001,False)
         self.grassThreshold = FindValueFromPercent(self.rainFallMap,mc.width,mc.height,mc.GrassPercent,.0001,False)
         for y in range(mc.height):
+	    lat = abs(mcDup.getLattitude(y))
             for x in range(mc.width):
                 i = GetIndex(x,y)
                 if self.plotMap[i] == mc.OCEAN:
@@ -2070,7 +2072,7 @@ class SmallMaps :
                     elif self.averageTempMap[i] < mc.TundraTemp:
                         self.terrainMap[i] = mc.TUNDRA
                     else:
-                        if self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain:
+                        if self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain and lat < (mc.horseLattitude + 4 +  int(PRand.random() * 3)) and lat > (mc.horseLattitude - 12 + int(PRand.random() * 4)):
                             self.terrainMap[i] = mc.DESERT
                         else:
                             if PRand.random() <= 0.5:
@@ -5022,6 +5024,7 @@ def generateTaiga():
 def generateRockSteppes():
 
     gc = CyGlobalContext()
+    mcDup = ClimateMap()
     mmap = gc.getMap()
     terrainPrairie = gc.getInfoTypeForString("TERRAIN_PLAINS")
     terrainPlains = gc.getInfoTypeForString("TERRAIN_PLAINS_FERTILE")
@@ -5031,6 +5034,7 @@ def generateRockSteppes():
     
     # Convert 3x3 of flat fertile river-less land to rock steppes to reflect arid land  
     for y in range(mc.height):
+	lat = abs(mcDup.getLattitude(y))
         for x in range(mc.width):
             plot = mmap.plot(x,y)
             if not plot.getPlotType() == PlotTypes.PLOT_PEAK:
@@ -5038,7 +5042,7 @@ def generateRockSteppes():
                     if not isAnyAdjacentPlotType(x, y, PlotTypes.PLOT_OCEAN):
                         if plot.getTerrainType() == terrainPrairie or plot.getTerrainType() == terrainPlains:
                             if isAllAdjacentPlotTerrainType(x, y, terrainPrairie) or isAllAdjacentPlotTerrainType(x, y, terrainPlains):
-                                if PRand.random() <= rockSteppesChance * 0.2:
+                                if PRand.random() <= rockSteppesChance or (sm.rainFallMap[GetIndex(x, y)] < 0.002):
                                     plot.setTerrainType(terrainRockSteppes, True, True)
                                     # Generate some Hills
                                     iRandPlotType = PRand.random()

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -115,7 +115,7 @@ class MapConstants :
         #How many map squares will be below desert rainfall threshold. In this case,
         #rain levels close to zero are very likely to be desert, while rain levels close
         #to the desert threshold will more likely be plains.
-        self.DesertPercent = 0.065
+        self.DesertPercent = 0.1
 
         #How many map squares will be below plains rainfall threshold. Rain levels close
         #to the desert threshold are likely to be plains, while those close to the plains
@@ -2073,8 +2073,8 @@ class SmallMaps :
                         self.terrainMap[i] = mc.SNOW
                     elif self.averageTempMap[i] < mc.TundraTemp:
                         self.terrainMap[i] = mc.TUNDRA
-                    else:
-                        if self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain and lat < (mc.horseLattitude + 4 +  int(PRand.random() * 3)) and lat > (mc.horseLattitude - 12 - int(PRand.random() * 4)):
+                      else:
+                        if (self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain) and (lat < (mc.horseLattitude + 5 +  int(PRand.random() * 4)) and lat > (mc.horseLattitude - 15 + int(PRand.random() * 4))):
                             self.terrainMap[i] = mc.DESERT
                         else:
                             if PRand.random() <= 0.5:

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -2074,7 +2074,7 @@ class SmallMaps :
                     elif self.averageTempMap[i] < mc.TundraTemp:
                         self.terrainMap[i] = mc.TUNDRA
                       else:
-                        if (self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain) and (lat < (mc.horseLattitude + 5 +  int(PRand.random() * 4)) and lat > (mc.horseLattitude - 15 + int(PRand.random() * 4))):
+                        if (self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain) and (lat < (mc.horseLattitude + 5 +  int(PRand.random() * 4)) and lat > (mc.horseLattitude - 15 - int(PRand.random() * 4))):
                             self.terrainMap[i] = mc.DESERT
                         else:
                             if PRand.random() <= 0.5:

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -5044,7 +5044,7 @@ def generateRockSteppes():
                     if not isAnyAdjacentPlotType(x, y, PlotTypes.PLOT_OCEAN):
                         if plot.getTerrainType() == terrainPrairie or plot.getTerrainType() == terrainPlains:
                             if isAllAdjacentPlotTerrainType(x, y, terrainPrairie) or isAllAdjacentPlotTerrainType(x, y, terrainPlains):
-                                if PRand.random() <= rockSteppesChance or (sm.rainFallMap[GetIndex(x, y)] < 0.002):
+                                if PRand.random() <= rockSteppesChance * 0.2 or (sm.rainFallMap[GetIndex(x, y)] < 0.002):
                                     plot.setTerrainType(terrainRockSteppes, True, True)
                                     # Generate some Hills
                                     iRandPlotType = PRand.random()

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -4956,8 +4956,6 @@ def generateShallowCoast():
                     elif PRand.random() <= shallowCoastChance:
                         plot.setTerrainType(terrainShallowCoast, True, True)
 
-def generateShrubland():
-    
     gc = CyGlobalContext()
     mmap = gc.getMap()
     terrainShrubland = gc.getInfoTypeForString("TERRAIN_SHRUBLAND")
@@ -4966,23 +4964,24 @@ def generateShrubland():
     terrainGrassland = gc.getInfoTypeForString("TERRAIN_GRASS")
     terrainDesert = gc.getInfoTypeForString("TERRAIN_DESERT")
 
-    shrublandChance = 0.5 # Baseline chance for converting terrains around desert to shrubland
-    shrublandNextToShrublandChance = 0.5 # Chance to create Shrubland next to other Shrubland
+    shrublandChance = 0.7 # Baseline chance for converting terrains around desert to shrubland
+    shrublandNextToShrublandChance = 0.85 # Chance to create Shrubland next to other Shrubland # slightly increased due to more strict desert criteria
     
     # Convert some prairie that's adjaceant to desert to shrubland 
     for y in range(mc.height):
+        lat = abs(cm.getLattitude(y))
         for x in range(mc.width):
             plot = mmap.plot(x,y)
-            if not plot.getPlotType() == PlotTypes.PLOT_PEAK:
+            if not plot.getPlotType() == PlotTypes.PLOT_PEAK: #and (plot.isRiver() and not isAnyAdjacentPlotTerrainType(x, y, terrainDesert)):
                 if plot.getTerrainType() == terrainPrairie or plot.getTerrainType() == terrainPlains or plot.getTerrainType() == terrainGrassland:
-                    if isAnyAdjacentPlotTerrainType(x, y, terrainDesert):
+                    if (isAnyAdjacentPlotTerrainType(x, y, terrainDesert) or isAnyAdjacentPlotTerrainType(x, y, terrainPlains) or isAnyAdjacentPlotTerrainType(x, y, terrainPrairie)) and (sm.rainFallMap[GetIndex(x, y)] < 0.0035 and sm.rainFallMap[GetIndex(x, y)] > 0.002 and sm.averageTempMap[GetIndex(x, y)] > 0.55):
                         if PRand.random() <= shrublandChance:
                             plot.setTerrainType(terrainShrubland, True, True)
                             iRandPlotType = PRand.random()
                             if iRandPlotType <= 0.3: 
                                 plot.setPlotType(PlotTypes.PLOT_HILLS,True,True)
                     elif isAnyAdjacentPlotTerrainType(x, y, terrainShrubland):
-                        if PRand.random() <= shrublandNextToShrublandChance:
+                        if PRand.random() <= shrublandNextToShrublandChance and sm.rainFallMap[GetIndex(x, y)] < 0.0035 and sm.rainFallMap[GetIndex(x, y)] > 0.002 and sm.averageTempMap[GetIndex(x, y)] > 0.5:
                             plot.setTerrainType(terrainShrubland, True, True)
                             iRandPlotType = PRand.random()
                             if iRandPlotType <= 0.3: 

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -2073,7 +2073,7 @@ class SmallMaps :
                         self.terrainMap[i] = mc.SNOW
                     elif self.averageTempMap[i] < mc.TundraTemp:
                         self.terrainMap[i] = mc.TUNDRA
-                      else:
+                    else:
                         if (self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain) and (lat < (mc.horseLattitude + 5 +  int(PRand.random() * 4)) and lat > (mc.horseLattitude - 15 - int(PRand.random() * 4))):
                             self.terrainMap[i] = mc.DESERT
                         else:
@@ -4956,6 +4956,8 @@ def generateShallowCoast():
                     elif PRand.random() <= shallowCoastChance:
                         plot.setTerrainType(terrainShallowCoast, True, True)
 
+def generateShrubland():
+	
     gc = CyGlobalContext()
     mmap = gc.getMap()
     terrainShrubland = gc.getInfoTypeForString("TERRAIN_SHRUBLAND")

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -2074,7 +2074,7 @@ class SmallMaps :
                     elif self.averageTempMap[i] < mc.TundraTemp:
                         self.terrainMap[i] = mc.TUNDRA
                     else:
-                        if self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain and lat < (mc.horseLattitude + 4 +  int(PRand.random() * 3)) and lat > (mc.horseLattitude - 12 + int(PRand.random() * 4)):
+                        if self.rainFallMap[i] < (PRand.random() * (self.desertThreshold - minRain) + self.desertThreshold - minRain)/2.0 + minRain and lat < (mc.horseLattitude + 4 +  int(PRand.random() * 3)) and lat > (mc.horseLattitude - 12 - int(PRand.random() * 4)):
                             self.terrainMap[i] = mc.DESERT
                         else:
                             if PRand.random() <= 0.5:

--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -1526,9 +1526,11 @@ class ClimateMap :
                 #average summer and winter
                 avgTemp = (self.summerTempsMap[i] + self.winterTempsMap[i])/2.0
                 #cool map for altitude
+		# attenuation so temperature per altitude increase drops less closer to equator to avoid glacier spam
+		latCorrectionFactor = (0.1 * (1.0 - math.sin(abs(math.radians(self.getLattitude(y)))))) ** 0.5
                 # TAC - Map scripts - koma13 - START
                 #self.averageTempMap.append(avgTemp * (1.0 - hm.getAltitudeAboveSeaLevel(x,y)))
-                self.averageTempMap.append(avgTemp * (1.0 - hm.getAltitudeAboveSeaLevel(x,y) ** 1.25))
+		self.averageTempMap.append(avgTemp * (1.0 - abs((hm.getAltitudeAboveSeaLevel(x,y) - latCorrectionFactor)) ** 1.25))
                 # TAC - Map scripts - koma13 - END
         
         #init moisture and rain maps


### PR DESCRIPTION
1) It confines the 'hot' sand deserts to around the horse latitudes as in the real world. Or to clarify: The yellow bright sand texture and cactee it can feature don't quite fit the higher up latitudes, hence:
2) It ramps up the odds for creating rock steppes in otherwise dry areas to simulate fells/"badlands"/barren ecoregions, that used to be sand deserts instead.
3) Adds a latitude-dependent attenuation factor to the decrease of temperature with height in order to avoid the glacier spam that often happens.
    This attenuation factor might not be optimal though, but the equator regions will no longer feature enormous glaciers.

4) I might have done something very "unpythonic" or noobish by using "mcDup = ClimateMap()" to invoke the getLatitude function from the climate class. But I think it's okay?