### PR TITLE
#949 Implement preferred starting direction for AI initial exploration

### DIFF
--- a/Project Files/DLLSources/CvGameCoreUtils.cpp
+++ b/Project Files/DLLSources/CvGameCoreUtils.cpp
@@ -168,6 +168,93 @@ float directionAngle( DirectionTypes eDirection )
 	}
 }
 
+// returns minimal number of steps (clockwise or counterclockwise) from one direction to another
+int getDirectionDiff(DirectionTypes direction1, DirectionTypes direction2)
+{
+	FAssertMsg(direction1 >= FIRST_DIRECTION && direction1 < NUM_DIRECTION_TYPES 
+		&& direction2 >= FIRST_DIRECTION && direction2 < NUM_DIRECTION_TYPES,
+		"Invalid DirectionTypes enum argument");
+
+	// in case one of directions is NO_DIRECTION
+	if (direction1 == NO_DIRECTION || direction2 == NO_DIRECTION)
+	{
+		if (direction1 == NO_DIRECTION && direction2 == NO_DIRECTION)
+		{
+			return 0;
+		}
+		else
+		{
+			return 1;
+		}
+	}
+
+	int diff = std::abs(direction1 - direction2);
+	if (diff <= NUM_DIRECTION_TYPES / 2)
+	{
+		return diff;
+	}
+	else
+	{
+		return NUM_DIRECTION_TYPES - diff;
+	}
+}
+
+DirectionTypes getDirectionFrom_dX_dY(int dX, int dY)
+{
+	int x, y;
+	if (dX < 0) x = -1;
+	else if (dX > 0) x = 1;
+	else x = 0;
+
+	if (dY < 0) y = -1;
+	else if (dY > 0) y = 1;
+	else y = 0;
+
+	switch (x)
+	{
+	case -1:
+		switch (y)
+		{
+		case -1:
+			return DIRECTION_SOUTHWEST;
+		case 0:
+			return DIRECTION_WEST;
+		case 1:
+			return DIRECTION_NORTHWEST;
+		default:
+			break;
+		}
+	case 0:
+		switch (y)
+		{
+		case -1:
+			return DIRECTION_SOUTH;
+		case 0:
+			return NO_DIRECTION;
+		case 1:
+			return DIRECTION_NORTH;
+		default:
+			break;
+		}
+	case 1:
+		switch (y)
+		{
+		case -1:
+			return DIRECTION_SOUTHEAST;
+		case 0:
+			return DIRECTION_EAST;
+		case 1:
+			return DIRECTION_NORTHEAST;
+		default:
+			break;
+		}
+	default:
+		break;
+	}
+
+	return NO_DIRECTION;
+}
+
 bool atWar(TeamTypes eTeamA, TeamTypes eTeamB)
 {
 	if (eTeamA == NO_TEAM || eTeamB == NO_TEAM)

--- a/Project Files/DLLSources/CvGameCoreUtils.h
+++ b/Project Files/DLLSources/CvGameCoreUtils.h
@@ -250,6 +250,8 @@ DllExport bool isCardinalDirection(DirectionTypes eDirection);
 DirectionTypes estimateDirection(int iDX, int iDY);
 DllExport DirectionTypes estimateDirection(const CvPlot* pFromPlot, const CvPlot* pToPlot);
 DllExport float directionAngle(DirectionTypes eDirection);
+int getDirectionDiff(DirectionTypes direction1, DirectionTypes direction2);
+DirectionTypes getDirectionFrom_dX_dY(int dX, int dY);
 bool atWar(TeamTypes eTeamA, TeamTypes eTeamB);
 bool isPotentialEnemy(TeamTypes eOurTeam, TeamTypes eTheirTeam);
 

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -24902,6 +24902,10 @@ void CvPlayer::writeDesyncLog(FILE *f) const
 // Function returns preferred direction for initial exploration basing on where starting plot is placed
 DirectionTypes CvPlayer::getPreferredStartingDirection() const
 {
+	if (getStartingPlot() == NULL) {
+		return NO_DIRECTION;
+	}
+	
 	int startX = getStartingPlot()->getX_INLINE();
 	int startY = getStartingPlot()->getY_INLINE();
 	int score[NUM_DIRECTION_TYPES] = { 0 };

--- a/Project Files/DLLSources/CvPlayer.h
+++ b/Project Files/DLLSources/CvPlayer.h
@@ -972,6 +972,8 @@ public:
 
 	void writeDesyncLog(FILE *f) const;
 
+	DirectionTypes getPreferredStartingDirection() const;
+
 protected:
 
 /** NBMOD REF **/

--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -12330,6 +12330,7 @@ bool CvUnitAI::AI_exploreOcean(int iRange)
 	CvPlot* pBestPlot = NULL;
 	CvPlot* pBestExplorePlot = NULL;
 	int iBestValue = 0;
+	DirectionTypes preferredDirection = GET_PLAYER(getOwnerINLINE()).getPreferredStartingDirection();
 
 	for (int iDX = -iRange; iDX <= iRange; iDX++)
 	{
@@ -12383,15 +12384,8 @@ bool CvUnitAI::AI_exploreOcean(int iRange)
 
 					if (GC.getGameINLINE().getGameTurn() < 10)
 					{
-						CvPlot* pStartingPlot = GET_PLAYER(getOwnerINLINE()).getStartingPlot();
-						if (pStartingPlot != NULL)
-						{
-							if ((std::abs(pLoopPlot->getX_INLINE() - pStartingPlot->getX_INLINE()) <= 1) || (std::abs(pLoopPlot->getY_INLINE() - pStartingPlot->getY_INLINE()) <= 1))
-							{
-								iValue *= 2;
-							}
-
-						}
+						DirectionTypes currentDirection = getDirectionFrom_dX_dY(iDX, iDY);
+						iValue += ((NUM_DIRECTION_TYPES / 2) - getDirectionDiff(currentDirection, preferredDirection)) * 100;
 					}
 
 					if (iValue > 0)


### PR DESCRIPTION
Improve AI starting exploration during first 10 turns (that number was hardcoded before, I didn't change this):
When on mission "explore ocean" starting ship now tends to aim itself to the direction, which is calculated basing on the surrounding of starting plot (how Europe tiles are situated, which Europe type they are).
The system is based on already implemented weight calculation system and should not break it.
The vessel still will choose next move basing not only on how close it is to new parameter "preferred direction", but also how many plots will be revealed and a bit of random.

**The result is:** 
On maps with big distance to Europe AI doesn't get lost in the ocean so often ;
-> reaches coast faster
-> first settlement is founded more quickly;
-> first settlement is in better location regarding distance to Europe

The implemented code can be improved a bit in part of performance, but it will increase complexity as well.
Also this code is executed only for the first several turns, so I think there is no need to bother.


**Remaining possible improvements (TODO):**
- teach AI to value tiles with unfavourable wind less than other tiles (it already succesfully avoids storm)
- maybe scale first 10 turns period depending on map size or game speed