### PR TITLE
#953 Fix Human Player units healing negative promotions anywhere

### DIFF
--- a/Project Files/DLLSources/CvUnit.cpp
+++ b/Project Files/DLLSources/CvUnit.cpp
@@ -814,7 +814,7 @@ void CvUnit::doTurn()
 	else
 	{
 		//WTP, ray Negative Promotions - START
-		if(!isHuman())
+		if(isHuman())
 		{
 			if (plot()->isCity())
 			{


### PR DESCRIPTION
Now AI can heal them everywhere, Human Player - only in settlements