### PR TITLE
New FF Competition Logic

### DIFF
--- a/Project Files/DLLSources/CvTeam.cpp
+++ b/Project Files/DLLSources/CvTeam.cpp
@@ -2507,10 +2507,8 @@ void CvTeam::changeUnitsPurchasedHistory(UnitClassTypes eIndex, int iChange)
 // Protected Functions...
 void CvTeam::testFoundingFather()
 {
-	for (int iFather = 0; iFather < GC.getNumFatherInfos(); ++iFather)
+	for (FatherTypes eFather = FIRST_FATHER; eFather < NUM_FATHER_TYPES; ++eFather)
 	{
-		FatherTypes eFather = (FatherTypes)iFather;
-
 		//This code was produced by Dyllin. Jan 2024
 		//Written to address a prior issue where only one FF was offered per turn,
 		//but that means if you rejected that FF, you didn't get another chance that turn.
@@ -2522,14 +2520,13 @@ void CvTeam::testFoundingFather()
 		if (canConvinceFather(eFather))
 		{
 			FatherPointTypes ePrimaryPointType = (FatherPointTypes)0;
-			FatherPointTypes ePoliticalPointType = (FatherPointTypes)4;
-			bool makeOffer = true;
-
-			for (int iFatherPointType = 0; iFatherPointType < GC.getNumFatherPointInfos(); iFatherPointType++)
+			bool bMakeOffer = true;
+			
+			for (FatherPointTypes ePointType = FIRST_FATHER_POINT; ePointType < NUM_FATHER_POINT_TYPES; ++ePointType)
 			{
-				if (getFatherPointCost(eFather, (FatherPointTypes)iFatherPointType) > getFatherPointCost(eFather, ePrimaryPointType))
+				if (getFatherPointCost(eFather, ePointType) > getFatherPointCost(eFather, ePrimaryPointType))
 				{
-					ePrimaryPointType = (FatherPointTypes)iFatherPointType;
+					ePrimaryPointType = ePointType;
 				}
 			}
 
@@ -2543,15 +2540,15 @@ void CvTeam::testFoundingFather()
 				{
 					if (kOtherTeam.getFatherPoints(ePrimaryPointType) > getFatherPoints(ePrimaryPointType))
 					{
-						makeOffer = false;
+						bMakeOffer = false;
 					}
 					else
 					{
 						if (kOtherTeam.getFatherPoints(ePrimaryPointType) == getFatherPoints(ePrimaryPointType))
 						{
-							if (kOtherTeam.getFatherPoints(ePoliticalPointType) > getFatherPoints(ePoliticalPointType))
+							if (kOtherTeam.getFatherPoints(FATHER_POINT_POLITICAL) > getFatherPoints(FATHER_POINT_POLITICAL))
 							{
-								makeOffer = false;
+								bMakeOffer = false;
 							}
 						}
 					}
@@ -2559,7 +2556,7 @@ void CvTeam::testFoundingFather()
 
 			}
 
-			if (makeOffer)
+			if (bMakeOffer)
 			{
 				if (isHuman()) //Check for any humans on THIS team
 				{
@@ -2571,7 +2568,7 @@ void CvTeam::testFoundingFather()
 							if (kPlayer.isHuman())
 							{
 								CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_FOUNDING_FATHER, eFather);
-								gDLL->getInterfaceIFace()->addPopup(pInfo, (PlayerTypes)iPlayer);
+								gDLL->getInterfaceIFace()->addPopup(pInfo, (PlayerTypes)iPlayer); //This line seems to wait for input from the player before moving on.
 							}
 						}
 					}

--- a/Project Files/DLLSources/CvTeam.cpp
+++ b/Project Files/DLLSources/CvTeam.cpp
@@ -2536,7 +2536,7 @@ void CvTeam::testFoundingFather()
 			{
 				CvTeam& kOtherTeam = GET_TEAM((TeamTypes)iTeam);
 
-				if (kOtherTeam.getID() != getID() && kOtherTeam.canConvinceFather(eFather))
+				if (kOtherTeam.getID() != getID() && kOtherTeam.canConvinceFather(eFather) && kOtherTeam.isAlive())
 				{
 					if (kOtherTeam.getFatherPoints(ePrimaryPointType) > getFatherPoints(ePrimaryPointType))
 					{

--- a/Project Files/DLLSources/CvTeam.cpp
+++ b/Project Files/DLLSources/CvTeam.cpp
@@ -2511,7 +2511,7 @@ void CvTeam::testFoundingFather()
 	{
 		FatherTypes eFather = (FatherTypes)iFather;
 
-		//This code was produced by Dyllin.
+		//This code was produced by Dyllin. Jan 2024
 		//Written to address a prior issue where only one FF was offered per turn,
 		//but that means if you rejected that FF, you didn't get another chance that turn.
 		//As a result, you could lose FFs further down the list to other colonies easily.
@@ -2527,7 +2527,7 @@ void CvTeam::testFoundingFather()
 
 			for (int iFatherPointType = 0; iFatherPointType < GC.getNumFatherPointInfos(); iFatherPointType++)
 			{
-				if (getFatherPointCost(eFather, (FatherPointTypes)iFatherPointType) >= getFatherPointCost(eFather, ePrimaryPointType))
+				if (getFatherPointCost(eFather, (FatherPointTypes)iFatherPointType) > getFatherPointCost(eFather, ePrimaryPointType))
 				{
 					ePrimaryPointType = (FatherPointTypes)iFatherPointType;
 				}

--- a/Project Files/DLLSources/HardcodedEnumSetup.h
+++ b/Project Files/DLLSources/HardcodedEnumSetup.h
@@ -59,6 +59,11 @@ enum EffectTypes
 	EFFECT_SETTLERSMOKE,
 };
 
+enum FatherPointTypes
+{
+	FATHER_POINT_POLITICAL,
+};
+
 enum LeaderHeadTypes
 {
 	LEADER_BARBARIAN,

--- a/Project Files/RaR.vcxproj
+++ b/Project Files/RaR.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Build Release|Win32">
       <Configuration>Build Release</Configuration>
@@ -404,90 +404,108 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3021AF0E-699D-4232-86F6-FC374A0C9957}</ProjectGuid>
     <Keyword>MakeFileProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Single core-Debug|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Single core-Profile|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Single core-Release|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Single core-Final Release|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Single core-Assert|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Multi core-Release|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML hardcoding-Release|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML hardcoding-Final Release|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Multi core-Final Release|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Build Release|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Multi core-Debug|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Debug|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML hardcoding-Debug|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Multi core-Profile|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML hardcoding-Profile|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Multi core-Assert|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='XML hardcoding-Assert|Win32'" Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CLRSupport>false</CLRSupport>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
New logic for how the FFs are offered. Now it's a competition between all colonies that can hire that FF this turn. Whoever has more of the primary point type of that FF wins. If it's deadlocked, then we check the political points, and if those are deadlocked, then it goes to the first team called, but that will be extremely unlikely.

This code addresses the "France gets first dibs" problem, and also makes it so you can get an infinite number of offered FFs as long as you have the points available still. I've tested it already, and it works.