### PR TITLE
Undo Fishing Nets Large Rivers Enabling

### DIFF
--- a/Assets/XML/Terrain/CIV4ImprovementInfos.xml
+++ b/Assets/XML/Terrain/CIV4ImprovementInfos.xml
@@ -6812,10 +6812,6 @@
 					<TerrainType>TERRAIN_COAST</TerrainType>
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
-				<TerrainMakesValid>
-					<TerrainType>TERRAIN_LARGE_RIVERS</TerrainType>
-					<bMakesValid>1</bMakesValid>
-				</TerrainMakesValid>
 			</TerrainMakesValids>
 			<FeatureMakesValids/>
 			<BonusTypeStructs/>


### PR DESCRIPTION
Unfortunately just flagging Large Rivers as okay apparently makes the game think all Large Rivers are okay. Yet this logic doesn't apply to Coasts and Shallow Coasts and so on. Makes no damn sense. I'm trying to think of a different solution.