### PR TITLE
River Fishing Nets Improvement Added

### DIFF
--- a/Assets/XML/Art/CIV4ArtDefines_Improvement.xml
+++ b/Assets/XML/Art/CIV4ArtDefines_Improvement.xml
@@ -376,6 +376,15 @@
 			<Button>,Art/colonization_atlas_buildings.dds,5,15</Button>
 		</ImprovementArtInfo>
 		<ImprovementArtInfo>
+			<Type>ART_DEF_IMPROVEMENT_FISHING_NETS_RIVER</Type>
+			<bExtraAnimations>0</bExtraAnimations>
+			<fScale>1.4</fScale>
+			<fInterfaceScale>1.0</fInterfaceScale>
+			<NIF>Art/Structures/Improvements/nets/FishingBoat.nif</NIF>
+			<KFM>Art/Structures/Improvements/nets/FishingBoat.kfm</KFM>
+			<Button>,Art/colonization_atlas_buildings.dds,5,15</Button>
+		</ImprovementArtInfo>
+		<ImprovementArtInfo>
 			<Type>ART_DEF_IMPROVEMENT_HUNTERS_STAGE</Type>
 			<bExtraAnimations>0</bExtraAnimations>
 			<fScale>1.4</fScale>

--- a/Assets/XML/Terrain/CIV4ImprovementInfos.xml
+++ b/Assets/XML/Terrain/CIV4ImprovementInfos.xml
@@ -6821,6 +6821,70 @@
 			<bGraphicalOnly>0</bGraphicalOnly>
 		</ImprovementInfo>
 		<ImprovementInfo>
+			<Type>IMPROVEMENT_FISHING_NETS_RIVER</Type>
+			<Description>TXT_KEY_IMPROVEMENT_FISHING_NETS_RIVER</Description>
+			<Civilopedia>TXT_KEY_IMPROVEMENT_FISHING_NETS_RIVER_PEDIA</Civilopedia>
+			<ArtDefineTag>ART_DEF_IMPROVEMENT_FISHING_NETS_RIVER</ArtDefineTag>
+			<PrereqNatureYields>
+				<YieldIntegerPair>
+					<YieldType>YIELD_FOOD</YieldType>
+					<iValue>3</iValue>
+				</YieldIntegerPair>
+				<YieldIntegerPair>
+					<YieldType>YIELD_GEMS</YieldType>
+					<iValue>2</iValue>
+				</YieldIntegerPair>
+			</PrereqNatureYields>
+			<YieldIncreases>
+				<YieldIntegerPair>
+					<YieldType>YIELD_FOOD</YieldType>
+					<iValue>1</iValue>
+				</YieldIntegerPair>
+				<YieldIntegerPair>
+					<YieldType>YIELD_GEMS</YieldType>
+					<iValue>1</iValue>
+				</YieldIntegerPair>
+			</YieldIncreases>
+			<RiverSideYieldChanges/>
+			<HillsYieldChanges/>
+			<bActsAsCity>0</bActsAsCity>
+			<bMonastery>0</bMonastery>
+			<bHillsMakesValid>0</bHillsMakesValid>
+			<bRiverSideMakesValid>0</bRiverSideMakesValid>
+			<bRequiresFlatlands>0</bRequiresFlatlands>
+			<bRequiresRiverSide>0</bRequiresRiverSide>
+			<bRequiresFeature>0</bRequiresFeature>
+			<bWater>1</bWater>
+			<bGoody>0</bGoody>
+			<bGoodyForSpawningUnits>0</bGoodyForSpawningUnits>
+			<bGoodyForSpawningHostileAnimals>0</bGoodyForSpawningHostileAnimals>
+			<bGoodyForSpawningHostileNatives>0</bGoodyForSpawningHostileNatives>
+			<bGoodyForSpawningHostileCriminals>0</bGoodyForSpawningHostileCriminals>
+			<bPermanent>0</bPermanent>
+			<bUseLSystem>0</bUseLSystem>
+			<iAdvancedStartCost>30</iAdvancedStartCost>
+			<iAdvancedStartCostIncrease>0</iAdvancedStartCostIncrease>
+			<iTilesPerGoody>0</iTilesPerGoody>
+			<iGoodyRange>0</iGoodyRange>
+			<iFeatureGrowth>0</iFeatureGrowth>
+			<iUpgradeTime>0</iUpgradeTime>
+			<iDefenseModifier>0</iDefenseModifier>
+			<iPillageGold>10</iPillageGold>
+			<bOutsideBorders>0</bOutsideBorders>
+			<TerrainMakesValids>
+				<TerrainMakesValid>
+					<TerrainType>TERRAIN_LARGE_RIVERS</TerrainType>
+					<bMakesValid>1</bMakesValid>
+				</TerrainMakesValid>
+			</TerrainMakesValids>
+			<FeatureMakesValids/>
+			<BonusTypeStructs/>
+			<ImprovementPillage/>
+			<ImprovementUpgrade/>
+			<RouteYieldChanges/>
+			<bGraphicalOnly>0</bGraphicalOnly>
+		</ImprovementInfo>
+		<ImprovementInfo>
 			<Type>IMPROVEMENT_HUNTERS_STAGE</Type>
 			<Description>TXT_KEY_IMPROVEMENT_HUNTERS_STAGE</Description>
 			<Civilopedia>TXT_KEY_IMPROVEMENT_HUNTERS_STAGE_PEDIA</Civilopedia>

--- a/Assets/XML/Text/XML_AUTO_UTF8_BuildInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_BuildInfo.xml
@@ -496,6 +496,20 @@
 		<Russian>Увеличивает продуктивность добычи ресурсов</Russian>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_BUILD_FISHING_NETS_RIVER</Tag>
+		<English>Build [LINK=IMPROVEMENT_FISHING_NETS_RIVER]river fishing nets[\LINK]</English>
+		<German>[LINK=IMPROVEMENT_FISHING_NETS_RIVER]Fischernetz am Fluss[\LINK] auslegen</German>
+		<French>Placer des [LINK=IMPROVEMENT_FISHING_NETS_RIVER]filets de pêche en rivière[\LINK]</French>
+		<Russian>Построить [COLOR_HIGHLIGHT_TEXT]рыбацкие сети[COLOR_REVERT]</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_BUILD_FISHING_NETS_RIVER_HELP</Tag>
+		<English>Increases fishing yields</English>
+		<German>Erhöht Erträge aus Fischfang</German>
+		<French>Augmente le produit de la pêche</French>
+		<Russian>Увеличивает продуктивность добычи ресурсов</Russian>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_BUILD_HUNTERS_STAGE</Tag>
 		<English>Build [LINK=IMPROVEMENT_HUNTERS_STAGE]hunters' blind[\LINK]</English>
 		<French>Construire des postes de chasses</French>

--- a/Assets/XML/Text/XML_AUTO_UTF8_ImprovementInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_ImprovementInfo.xml
@@ -1246,6 +1246,22 @@
 		<German>[ICON_BULLET]Kann nur angrenzend an [COLOR_UNIT_TEXT]Wassergeländefelder[COLOR_REVERT], wie z.B. Küsten, flache Küsten, große Flüsse, Seen oder Eisseen gebaut werden [NEWLINE][ICON_BULLET]Erlaubt [COLOR_UNIT_TEXT]Küstenschiffen [COLOR_REVERT] und [COLOR_UNIT_TEXT]Fischerbooten[COLOR_REVERT] die Durchfahrt über [COLOR_HIGHLIGHT_TEXT]Land[COLOR_REVERT]</German>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_IMPROVEMENT_FISHING_NETS_RIVER</Tag>
+		<English>River Fishing Nets</English>
+		<French>Filet de Pêche en Rivière</French>
+		<German>
+			<Text>Fischernetz am Fluss</Text>
+			<Gender>Neuter</Gender>
+			<Plural>1</Plural>
+		</German>
+		<Russian>Сеть для речной рыбалки</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_IMPROVEMENT_FISHING_NETS_RIVER_PEDIA</Tag>
+		<English>[COLOR_HIGHLIGHT_TEXT]Fishing nets[COLOR_REVERT] can be woven to scoop up a shoal of fish or, with gill nets, to trap fish of the desired size. It's one of the two main systems used by fishing boats, the other being trawling with hooks.</English>
+		<German>[COLOR_HIGHLIGHT_TEXT]Fischernetze[COLOR_REVERT] werden genutzt um einen Fischschwarm zu fangen, oder mit sogenannten Kiemennetzen auch nur Fische einer bestimmten Größe. Daneben gibt es noch ein anderes Hauptsystem, das von Fischern verwendet wird: das Schleppnetz, welches mit einem Haken hinter dem Schiff hergezogen wird.</German>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_IMPROVEMENT_FISHING_NETS</Tag>
 		<English>Fishing Nets</English>
 		<French>Filets de pêche</French>

--- a/Assets/XML/Units/CIV4BuildInfos.xml
+++ b/Assets/XML/Units/CIV4BuildInfos.xml
@@ -4375,6 +4375,27 @@
 			<Button>Art\Interface\Game Hud\Actions\Button_EstablishFishNet.dds</Button>
 		</BuildInfo>
 		<BuildInfo>
+			<Type>BUILD_FISHING_NETS_RIVER</Type>
+			<Description>TXT_KEY_BUILD_FISHING_NETS_RIVER</Description>
+			<Help>TXT_KEY_BUILD_FISHING_NETS_RIVER_HELP</Help>
+			<iTime>1000</iTime>
+			<iCost>100</iCost>
+			<bKill>0</bKill>
+			<ImprovementType>IMPROVEMENT_FISHING_NETS_RIVER</ImprovementType>
+			<PrereqTerrainType>NONE</PrereqTerrainType>
+			<ResultTerrainType>NONE</ResultTerrainType>
+			<ResultFeatureType>NONE</ResultFeatureType>
+			<RouteType>NONE</RouteType>
+			<EntityEvent>ENTITY_EVENT_BUILD</EntityEvent>
+			<FeatureStructs/>
+			<HotKey>KB_R</HotKey>
+			<bAltDown>0</bAltDown>
+			<bShiftDown>0</bShiftDown>
+			<bCtrlDown>0</bCtrlDown>
+			<iHotKeyPriority>0</iHotKeyPriority>
+			<Button>Art\Interface\Game Hud\Actions\Button_EstablishFishNet.dds</Button>
+		</BuildInfo>
+		<BuildInfo>
 			<Type>BUILD_HUNTERS_STAGE</Type>
 			<Description>TXT_KEY_BUILD_HUNTERS_STAGE</Description>
 			<Help>TXT_KEY_BUILD_HUNTERS_STAGE_HELP</Help>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -83199,6 +83199,10 @@
 					<bBuild>1</bBuild>
 				</Build>
 				<Build>
+					<BuildType>BUILD_FISHING_NETS_RIVER</BuildType>
+					<bBuild>1</bBuild>
+				</Build>
+				<Build>
 					<BuildType>BUILD_HUNTERS_STAGE</BuildType>
 					<bBuild>1</bBuild>
 				</Build>

--- a/Project Files/DLLSources/CvGameTextMgr.cpp
+++ b/Project Files/DLLSources/CvGameTextMgr.cpp
@@ -7404,7 +7404,8 @@ void CvGameTextMgr::setImprovementHelp(CvWStringBuffer &szBuffer, ImprovementTyp
 		// WTP, ray, Not allowed next to itself - END
 
 		//WTP, ray, Large Rivers - START
-		if (info.getTerrainMakesValid(TERRAIN_LARGE_RIVERS))
+		//Not all improvements on Large Rivers allow crossing anymore, modifying to be more specific. -Dyllin Jan 2024
+		if (strcmp("IMPROVEMENT_RAFT_STATION", info.getType()) == 0)
 		{
 			szBuffer.append(NEWLINE);
 			szBuffer.append(gDLL->getText("TXT_KEY_IMPROVEMENT_ALLOWS_CROSSING_OF_LARGE_RIVERS"));


### PR DESCRIPTION
Prior solution to Fishing Nets working on Large Rivers didn't work due to a misunderstanding on my part of how the game enabled Fishing Nets. This solution is the only solution I can think of at the moment, which is to add a new River Fishing Nets improvement. Doing this ended up being a pain, but it works.

I also had to modify CvGameTextMgr.cpp to stop saying that River Fishing Nets allowed land units to cross, as there was a generic check for TERRAIN_LARGE_RIVERS making an improvement valid that supposedly meant all land units could cross. Not all improvements build on Large Rivers allow crossing, so I had to make this function more specific for river ferries.