### PR TITLE
Founding Fathers Name Updates

### DIFF
--- a/Assets/XML/Text/XML_AUTO_UTF8_FatherInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_FatherInfo.xml
@@ -4067,7 +4067,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_WILLEM_BARENTS</Tag>
 		<English>
-			<Text>Willem Barentsz</Text>
+			<Text>William Barentsz</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</English>
@@ -4077,17 +4077,17 @@
 			<Plural>0</Plural>
 		</French>
 		<German>
-			<Text>Willem Barentsz</Text>
+			<Text>Willem Barents</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>Willem Barentsz</Text>
+			<Text>Willem Barents</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>Willem Barentsz</Text>
+			<Text>Willem Barents</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
@@ -4108,39 +4108,39 @@
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_JOHANN_MORITZ</Tag>
 		<English>
-			<Text>Johann Moritz</Text>
+			<Text>John Maurice of Nassau</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</English>
 		<French>
-			<Text>Fürst von Nassau-Siegen</Text>
+			<Text>Jean-Maurice de Nassau</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</French>
 		<German>
-			<Text>Fürst von Nassau-Siegen</Text>
+			<Text>Johann Moritz von Nassau</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>Fürst von Nassau-Siegen</Text>
+			<Text>Giovanni Maurizio di Nassau</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>Fürst von Nassau-Siegen</Text>
+			<Text>Juan Mauricio de Nassau</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Иоганн Мориц Нассау-Зигенский</Russian>
+		<Russian>Иоганн Мориц Нассау</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_JOHANN_MORITZ_PEDIA</Tag>
-		<English>[H1]Johann Moritz, Fürst von Nassau-Siegen[\H1][NEWLINE][BOLD]Lived : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Background :[\BOLD][PARAGRAPH:1:1]Johann Moritz von Nassau-Siegen was a Dutch field marshal and gouverneur-generaal of Nieuw-Holland from 1636 to 1643. After his appointment as gouverneur-generaal of the possessions of the Dutch West India Company in Brazil in 1636, he conquered a large part of the northeastern coast of Brazil from the Portuguese despite having only small forces at his disposal. Subsequently, in 1637, Johann Moritz sent an expedition of nine ships and 800 soldiers to the African coast, which captured for the Dutch the Portuguese fortress and most important trading post on the coast of Guinea, São Jorge da Mina. Elmina then became the Dutch headquarters in West Africa and one of the starting points of the transatlantic slave trade. With the massive use of African slaves on the extensive sugar plantations, Johann Moritz contributed significantly to the rise of Nieuw-Holland whose "white gold" brought great profits to the Dutch West India Company. The economic success of the Dutch spurred the Portuguese even more to reconquer their colony, which they succeeded in doing by 1654.</English>
-		<French>[H1]Johann Moritz, Fürst von Nassau-Siegen[\H1][NEWLINE][BOLD]Dates : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Biographie :[\BOLD][PARAGRAPH:1:1]Johann Moritz, de Nassau-Siegen, était maréchal des Pays-Bas et gouverneur général de la Nouvelle-Hollande de 1636 à 1643. Après sa nomination comme gouverneur général des possessions de la Compagnie néerlandaise des Indes occidentales au Brésil en 1636, il s'empara d'une grande partie de la côte nord-est du Brésil aux mains des Portugais, bien qu'il n'ait que peu de forces à sa disposition. Par la suite, en 1637, Johann Moritz envoya une expédition de neuf navires et 800 soldats sur la côte africaine, qui captura pour les Hollandais la forteresse portugaise et le plus important poste de commerce de la côte guinéenne, São Jorge da Mina. Elmina est ensuite devenue le siège des Pays-Bas en Afrique de l'Ouest et l'un des points de départ de la traite transatlantique des esclaves. Avec l'utilisation massive d'esclaves africains dans les grandes plantations de sucre, Johann Moritz a contribué de manière significative à l'essor de la Nieuw-Holland, dont "l'or blanc" a rapporté de grands profits à la Compagnie néerlandaise des Indes occidentales. Le succès économique des Hollandais incite encore plus les Portugais à reconquérir leur colonie, ce qu'ils réussissent à faire en 1654.</French>
-		<German>[H1]Johann Moritz, Fürst von Nassau-Siegen[\H1][NEWLINE][BOLD]Lebte : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Hintergrund :[\BOLD][PARAGRAPH:1:1]Johann Moritz von Nassau-Siegen war ein niederländischer Feldmarschall und General-Gouverneur von Nieuw-Holland von 1636 bis 1643. Nach seiner Ernennung zum gouverneur-generaal der Besitzungen der Niederländischen Westindien-Kompanie in Brasilien 1636 eroberte er, obwohl er nur geringe Streitkräfte zur Verfügung hatte, einen großen Teil der nordöstlichen Küste Brasiliens von den Portugiesen. Anschließend entsandte Johann Moritz 1637 eine Expedition mit neun Schiffen und 800 Soldaten an die afrikanische Küste, die für die Holländer die portugiesische Festung und wichtigste Handelsniederlassung an der Küste von Guinea, São Jorge da Mina, eroberte. Elmina wurde danach das Hauptquartier der Niederländer in Westafrika und einer der Ausgangspunkte des transatlantischen Sklavenhandels. Mit dem massiven Einsatz afrikanischer Sklaven auf den ausgedehnten Zuckerplantagen trug Johann Moritz maßgeblich zum Aufstieg von Nieuw-Holland bei, dessen "Weißes Gold" der niederländischen Westindien-Kompanie große Profite brachte. Der wirtschaftliche Erfolg der Holländer stachelte die Portugiesen noch mehr an, ihre Kolonie zurückzuerobern, was ihnen bis 1654 auch gelang.</German>
-		<Italian>[H1]Johann Moritz, Fürst von Nassau-Siegen[\H1][NEWLINE][BOLD]Vita : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Informazioni :[\BOLD][PARAGRAPH:1:1]Johann Moritz di Nassau-Siegen fu un feldmaresciallo olandese e governatore generale di Nieuw-Holland dal 1636 al 1643. Dopo la sua nomina a gouverneur-generaal dei possedimenti della Compagnia Olandese delle Indie Occidentali in Brasile nel 1636, catturò gran parte della costa nord-orientale del Brasile dai portoghesi, sebbene avesse poche forze a sua disposizione. Successivamente, nel 1637, Johann Moritz inviò una spedizione di nove navi e 800 soldati sulla costa africana, che catturò per gli olandesi la fortezza portoghese e il più importante posto commerciale sulla costa della Guinea, São Jorge da Mina. Elmina divenne in seguito il quartier generale olandese in Africa occidentale e uno dei punti di partenza della tratta transatlantica degli schiavi. Con l'uso massiccio di schiavi africani nelle estese piantagioni di zucchero, Johann Moritz contribuì significativamente all'ascesa di Nieuw-Holland, il cui "oro bianco" portò grandi profitti alla Compagnia olandese delle Indie occidentali. Il successo economico degli olandesi spronò ancora di più i portoghesi a riconquistare la loro colonia, cosa che riuscirono a fare nel 1654.</Italian>
-		<Spanish>[H1]Johann Moritz, Fürst von Nassau-Siegen[\H1][NEWLINE][BOLD]Vivió : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Biografía :[\BOLD][PARAGRAPH:1:1]Johann Moritz de Nassau-Siegen fue un mariscal de campo holandés y gobernador general de Nueva Holanda de 1636 a 1643. Tras su nombramiento como gouverneur-generaal de las posesiones de la Compañía Holandesa de las Indias Occidentales en Brasil en 1636, capturó gran parte de la costa noreste de Brasil a los portugueses, aunque tenía pocas fuerzas a su disposición. Posteriormente, en 1637, Johann Moritz envió una expedición de nueve barcos y 800 soldados a la costa africana, que capturó para los holandeses la fortaleza portuguesa y el puesto comercial más importante de la costa de Guinea, São Jorge da Mina. Posteriormente, Elmina se convirtió en el cuartel general holandés en África Occidental y en uno de los puntos de partida del comercio transatlántico de esclavos. Con el uso masivo de esclavos africanos en las extensas plantaciones de azúcar, Johann Moritz contribuyó significativamente al auge de Nieuw-Holland, cuyo "oro blanco" reportó grandes beneficios a la Compañía Holandesa de las Indias Occidentales. El éxito económico de los holandeses espoleó aún más a los portugueses para reconquistar su colonia, lo que consiguieron en 1654.</Spanish>
+		<English>[H1]Johan Maurits van Nassau-Siegen, Prince of Nassau-Siegen[\H1][NEWLINE][BOLD]Lived : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Background :[\BOLD][PARAGRAPH:1:1]Johann Moritz von Nassau-Siegen was a Dutch field marshal and gouverneur-generaal of Nieuw-Holland from 1636 to 1643. After his appointment as gouverneur-generaal of the possessions of the Dutch West India Company in Brazil in 1636, he conquered a large part of the northeastern coast of Brazil from the Portuguese despite having only small forces at his disposal. Subsequently, in 1637, Johann Moritz sent an expedition of nine ships and 800 soldiers to the African coast, which captured for the Dutch the Portuguese fortress and most important trading post on the coast of Guinea, São Jorge da Mina. Elmina then became the Dutch headquarters in West Africa and one of the starting points of the transatlantic slave trade. With the massive use of African slaves on the extensive sugar plantations, Johann Moritz contributed significantly to the rise of Nieuw-Holland whose "white gold" brought great profits to the Dutch West India Company. The economic success of the Dutch spurred the Portuguese even more to reconquer their colony, which they succeeded in doing by 1654.</English>
+		<French>[H1]Johan Maurits van Nassau-Siegen, Prince de Nassau-Siegen[\H1][NEWLINE][BOLD]Dates : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Biographie :[\BOLD][PARAGRAPH:1:1]Johann Moritz, de Nassau-Siegen, était maréchal des Pays-Bas et gouverneur général de la Nouvelle-Hollande de 1636 à 1643. Après sa nomination comme gouverneur général des possessions de la Compagnie néerlandaise des Indes occidentales au Brésil en 1636, il s'empara d'une grande partie de la côte nord-est du Brésil aux mains des Portugais, bien qu'il n'ait que peu de forces à sa disposition. Par la suite, en 1637, Johann Moritz envoya une expédition de neuf navires et 800 soldats sur la côte africaine, qui captura pour les Hollandais la forteresse portugaise et le plus important poste de commerce de la côte guinéenne, São Jorge da Mina. Elmina est ensuite devenue le siège des Pays-Bas en Afrique de l'Ouest et l'un des points de départ de la traite transatlantique des esclaves. Avec l'utilisation massive d'esclaves africains dans les grandes plantations de sucre, Johann Moritz a contribué de manière significative à l'essor de la Nieuw-Holland, dont "l'or blanc" a rapporté de grands profits à la Compagnie néerlandaise des Indes occidentales. Le succès économique des Hollandais incite encore plus les Portugais à reconquérir leur colonie, ce qu'ils réussissent à faire en 1654.</French>
+		<German>[H1]Johan Maurits van Nassau-Siegen, Fürst von Nassau-Siegen[\H1][NEWLINE][BOLD]Lebte : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Hintergrund :[\BOLD][PARAGRAPH:1:1]Johann Moritz von Nassau-Siegen war ein niederländischer Feldmarschall und General-Gouverneur von Nieuw-Holland von 1636 bis 1643. Nach seiner Ernennung zum gouverneur-generaal der Besitzungen der Niederländischen Westindien-Kompanie in Brasilien 1636 eroberte er, obwohl er nur geringe Streitkräfte zur Verfügung hatte, einen großen Teil der nordöstlichen Küste Brasiliens von den Portugiesen. Anschließend entsandte Johann Moritz 1637 eine Expedition mit neun Schiffen und 800 Soldaten an die afrikanische Küste, die für die Holländer die portugiesische Festung und wichtigste Handelsniederlassung an der Küste von Guinea, São Jorge da Mina, eroberte. Elmina wurde danach das Hauptquartier der Niederländer in Westafrika und einer der Ausgangspunkte des transatlantischen Sklavenhandels. Mit dem massiven Einsatz afrikanischer Sklaven auf den ausgedehnten Zuckerplantagen trug Johann Moritz maßgeblich zum Aufstieg von Nieuw-Holland bei, dessen "Weißes Gold" der niederländischen Westindien-Kompanie große Profite brachte. Der wirtschaftliche Erfolg der Holländer stachelte die Portugiesen noch mehr an, ihre Kolonie zurückzuerobern, was ihnen bis 1654 auch gelang.</German>
+		<Italian>[H1]Johan Maurits van Nassau-Siegen, Principe di Nassau-Siegen[\H1][NEWLINE][BOLD]Vita : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Informazioni :[\BOLD][PARAGRAPH:1:1]Johann Moritz di Nassau-Siegen fu un feldmaresciallo olandese e governatore generale di Nieuw-Holland dal 1636 al 1643. Dopo la sua nomina a gouverneur-generaal dei possedimenti della Compagnia Olandese delle Indie Occidentali in Brasile nel 1636, catturò gran parte della costa nord-orientale del Brasile dai portoghesi, sebbene avesse poche forze a sua disposizione. Successivamente, nel 1637, Johann Moritz inviò una spedizione di nove navi e 800 soldati sulla costa africana, che catturò per gli olandesi la fortezza portoghese e il più importante posto commerciale sulla costa della Guinea, São Jorge da Mina. Elmina divenne in seguito il quartier generale olandese in Africa occidentale e uno dei punti di partenza della tratta transatlantica degli schiavi. Con l'uso massiccio di schiavi africani nelle estese piantagioni di zucchero, Johann Moritz contribuì significativamente all'ascesa di Nieuw-Holland, il cui "oro bianco" portò grandi profitti alla Compagnia olandese delle Indie occidentali. Il successo economico degli olandesi spronò ancora di più i portoghesi a riconquistare la loro colonia, cosa che riuscirono a fare nel 1654.</Italian>
+		<Spanish>[H1]Johan Maurits van Nassau-Siegen, Principe de Nassau-Siegen[\H1][NEWLINE][BOLD]Vivió : [\BOLD]1604 - 1679[NEWLINE][NEWLINE][BOLD]Biografía :[\BOLD][PARAGRAPH:1:1]Johann Moritz de Nassau-Siegen fue un mariscal de campo holandés y gobernador general de Nueva Holanda de 1636 a 1643. Tras su nombramiento como gouverneur-generaal de las posesiones de la Compañía Holandesa de las Indias Occidentales en Brasil en 1636, capturó gran parte de la costa noreste de Brasil a los portugueses, aunque tenía pocas fuerzas a su disposición. Posteriormente, en 1637, Johann Moritz envió una expedición de nueve barcos y 800 soldados a la costa africana, que capturó para los holandeses la fortaleza portuguesa y el puesto comercial más importante de la costa de Guinea, São Jorge da Mina. Posteriormente, Elmina se convirtió en el cuartel general holandés en África Occidental y en uno de los puntos de partida del comercio transatlántico de esclavos. Con el uso masivo de esclavos africanos en las extensas plantaciones de azúcar, Johann Moritz contribuyó significativamente al auge de Nieuw-Holland, cuyo "oro blanco" reportó grandes beneficios a la Compañía Holandesa de las Indias Occidentales. El éxito económico de los holandeses espoleó aún más a los portugueses para reconquistar su colonia, lo que consiguieron en 1654.</Spanish>
 	</TEXT>
 	<TEXT>
 	<Tag>TXT_KEY_FATHER_JOHANN_MORITZ_STRATEGY</Tag>
@@ -4153,27 +4153,27 @@
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_HERMAN_OF_ALASKA</Tag>
 		<English>
-			<Text>German Alyaskinskiy</Text>
+			<Text>Herman of Alaska</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</English>
 		<French>
-			<Text>German Alyaskinskiy</Text>
+			<Text>Germain d'Alaska</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</French>
 		<German>
-			<Text>German Alyaskinskiy</Text>
+			<Text>Herman von Alaska</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>German Alyaskinskiy</Text>
+			<Text>Germano d'Alasca</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>German Alyaskinskiy</Text>
+			<Text>Germán de Alaska</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
@@ -4192,27 +4192,27 @@
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_NIKOLAI_REZANOV</Tag>
 		<English>
-			<Text>Nikolay Petrovich Rezanov</Text>
+			<Text>Nikolai Petrovich Rezanov</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</English>
 		<French>
-			<Text>Nikolay Petrovich Rezanov</Text>
+			<Text>Nikolaï Petrovitch Rezanov</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</French>
 		<German>
-			<Text>Nikolay Petrovich Rezanov</Text>
+			<Text>Nikolai Petrowitsch Resanow</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>Nikolay Petrovich Rezanov</Text>
+			<Text>Nikolaj Petrovič Rezanov</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>Nikolay Petrovich Rezanov</Text>
+			<Text>Nikolái Petróvich Rezánov</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
@@ -4241,7 +4241,7 @@
 			<Plural>0</Plural>
 		</French>
 		<German>
-			<Text>Ivan Aleksandrovich Kuskov</Text>
+			<Text>Iwan Alexandrowitsch Kuskow</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</German>
@@ -4251,7 +4251,7 @@
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>Ivan Aleksandrovich Kuskov</Text>
+			<Text>Iván Aleksándrovich Kuskov</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
@@ -4270,27 +4270,27 @@
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_IVAN_KRUZENSHTERN</Tag>
 		<English>
-			<Text>Ivan Fyodorovich Krusenstern</Text>
+			<Text>Adam Johann von Krusenstern</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</English>
 		<French>
-			<Text>Ivan Fyodorovich Krusenstern</Text>
+			<Text>Adam Jean de Krusenstern</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</French>
 		<German>
-			<Text>Ivan Fyodorovich Krusenstern</Text>
+			<Text>Adam Johann von Krusenstern</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>Ivan Fyodorovich Krusenstern</Text>
+			<Text>Adam Johann von Krusenstern</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>Ivan Fyodorovich Krusenstern</Text>
+			<Text>Adam Johann von Krusenstern</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>

--- a/Assets/XML/Text/XML_AUTO_UTF8_FatherInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_FatherInfo.xml
@@ -18,7 +18,7 @@
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>Adam Smith</Text>
+			<Text>Adamo Smith</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
@@ -98,7 +98,7 @@
 			<Plural>0</Plural>
 		</English>
 		<French>
-			<Text>Alexander von Humboldt</Text>
+			<Text>Alexandre de Humboldt</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</French>
@@ -138,27 +138,27 @@
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_ALEXIS_DE_TOCQUEVILLE</Tag>
 		<English>
-			<Text>Comte de Tocqueville</Text>
+			<Text>Alexis de Tocqueville</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</English>
 		<French>
-			<Text>Comte de Tocqueville</Text>
+			<Text>Alexis de Tocqueville</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</French>
 		<German>
-			<Text>Comte de Tocqueville</Text>
+			<Text>Alexis de Tocqueville</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>Comte de Tocqueville</Text>
+			<Text>Alexis de Tocqueville</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>Comte de Tocqueville</Text>
+			<Text>Alexis de Tocqueville</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
@@ -196,12 +196,12 @@
 			<Plural>0</Plural>
 		</German>
 		<Italian>
-			<Text>Bartolomé de Las Casas</Text>
+			<Text>Bartolomeo de Las Casas</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Italian>
 		<Spanish>
-			<Text>Fray Bartolomé de Las Casas</Text>
+			<Text>Bartolomé de Las Casas</Text>
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
@@ -213,7 +213,7 @@
 		<French>[H1]Bartolomé de Las Casas[\H1][NEWLINE][BOLD]Dates : [\BOLD]1484 - 1566[NEWLINE][NEWLINE][BOLD]Biographie :[\BOLD][PARAGRAPH:1:1]Bartolomé de Las Casas commence sa carrière au Nouveau Monde comme conquistador au début du XVIe siècle. Là, il est témoin des atrocités commises par les gouverneurs espagnols contre les citoyens indigènes, avant de rentrer en Espagne pour achever ses études religieuses. Il rejoint l'ordre dominicain et regagne le Nouveau Monde, en demandant la fin de l'encomienda : un système d'esclavage complexe entraînant la fin des sociétés indigènes. Ses propos virulents finissent par attirer l'attention des puissants espagnols, qui organisent un débat présidé par le roi Charles V d'Espagne. Les arguments que Las Casas avance avec véhémence lui permettent de remporter le débat, mais pas de sauver la population indigène déjà décimée.</French>
 		<German>[H1]Bartolomé de Las Casas[\H1][NEWLINE][BOLD]Lebte : [\BOLD]1484 - 1566[NEWLINE][NEWLINE][BOLD]Hintergrund :[\BOLD][PARAGRAPH:1:1]Bartolomé de Las Casas begann seine Karriere in der Neuen Welt, die er zu Anfang des 16. Jahrhunderts besuchte, als Konquistador. Dort wurde er Zeuge der Gräueltaten, welche die spanischen Gouverneure an der einheimischen Bevölkerung verübten. Er kehrte zurück nach Spanien und schloss dort seine religiösen Studien ab. Er trat dem Dominikanerorden bei und reiste erneut in die Neue Welt, wo er das Ende der Encomienda forderte, eines komplexen Systems der Sklaverei, das die einheimische Gesellschaft allmählich auslöschte. Er schlug solchen Krach, dass die Mächtigen in Spanien auf ihn aufmerksam wurden und unter Vorsitz des spanischen Königs Karl V. eine Debatte organisierten. Mit leidenschaftlich vorgetragenen Argumenten gewann er die Debatte, konnte aber die bereits stark dezimierte eingeborene Bevölkerung dennoch nicht retten.</German>
 		<Italian>[H1]Bartolomé de Las Casas[\H1][NEWLINE][BOLD]Vita : [\BOLD]1484 - 1566[NEWLINE][NEWLINE][BOLD]Informazioni :[\BOLD][PARAGRAPH:1:1]Bartolomé de Las Casas cominciò la propria carriera nel Nuovo Mondo come conquistador, arrivandovi all'inizio del XVI secolo. Nel Nuovo Mondo assistette alle atrocità perpetrate dai governatori spagnoli ai danni dei nativi, prima di tornare in Spagna per completare gli studi religiosi. Entrò nell'ordine dei domenicani e tornò nel Nuovo Mondo, domandando che venisse posta fine all'encomienda: un complesso sistema di schiavitù che stava completamente eliminando la società dei nativi. Le sue prediche attirarono l'attenzione dei potenti di Spagna, che organizzarono un dibattito presieduto dal re spagnolo, Carlo V. Le sue fervide argomentazioni gli fecero vincere il confronto, anche se non furono in grado di salvare la popolazione nativa, già decimata.</Italian>
-		<Spanish>[H1]Fray Bartolomé de Las Casas[\H1][NEWLINE][BOLD]Vivió : [\BOLD]1484 - 1566[NEWLINE][NEWLINE][BOLD]Biografía :[\BOLD][PARAGRAPH:1:1]Bartolomé de Las Casas empezó su carrera en el Nuevo Mundo como conquistador, visitándolo a inicios del s. XVI. Allí presenció las atrocidades cometidas por los gobernadores españoles con los ciudadanos indígenas, antes de volver a España a completar su formación religiosa. Entró en la Orden de los Dominicos y regresó al Nuevo Mundo para exigir que se pusiera fin al sistema de las encomiendas (un intrincado sistema esclavista que estaba acabando con la sociedad indígena). Sus arengas llamaron la atención de los poderosos en España, que organizarían un debate que presidiría el mismísimo rey español, Carlos V. Sus apasionados argumentos le dieron la victoria en éste, pero con ello no consiguió salvar a una población nativa que ya estaba diezmada.</Spanish>
+		<Spanish>[H1]Bartolomé de Las Casas[\H1][NEWLINE][BOLD]Vivió : [\BOLD]1484 - 1566[NEWLINE][NEWLINE][BOLD]Biografía :[\BOLD][PARAGRAPH:1:1]Bartolomé de Las Casas empezó su carrera en el Nuevo Mundo como conquistador, visitándolo a inicios del s. XVI. Allí presenció las atrocidades cometidas por los gobernadores españoles con los ciudadanos indígenas, antes de volver a España a completar su formación religiosa. Entró en la Orden de los Dominicos y regresó al Nuevo Mundo para exigir que se pusiera fin al sistema de las encomiendas (un intrincado sistema esclavista que estaba acabando con la sociedad indígena). Sus arengas llamaron la atención de los poderosos en España, que organizarían un debate que presidiría el mismísimo rey español, Carlos V. Sus apasionados argumentos le dieron la victoria en éste, pero con ello no consiguió salvar a una población nativa que ya estaba diezmada.</Spanish>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_BARTOLOME_DE_LAS_CASAS_STRATEGY</Tag>


### PR DESCRIPTION
Fixing in different language names for Founding Fathers.
Johann Moritz line (4108) left intact, but his name in code should be changed to reflect the correct english name, akin to the standirization used with other fathers.
As I have no knowledge on how this would affect other areas of the code, left it untouched, so only things that changed were how the names show in-game.
Johann Moritz Pedia text also changed to reflect his Dutch name in all entries, as common in other Founding Fathers, having their original language name in the Pedia description.
Also notice that the title Furst (Prince in German) was also changed in all lines to reflect the correct language of the text it's writen on, ending all possible mistakes when reading it.
-----
More name language updates. Stopped since there seems to be a need in better representing the various nations of the continent, which deems updating FF's names to their correct names in different languages potentially redundant given the possibility of removal.
Will address such matters when the list of FF's is definite.