### PR TITLE
Restore "Sir" prefix to knight characters in Russian translation

### DIFF
--- a/Assets/XML/Text/CIV4GameText_WTP_New_Founding_Fathers_utf8.xml
+++ b/Assets/XML/Text/CIV4GameText_WTP_New_Founding_Fathers_utf8.xml
@@ -72,7 +72,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Томас Гейтс</Russian>
+		<Russian>Сэр Томас Гейтс</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_SIR_THOMAS_GATES_PEDIA</Tag>
@@ -150,7 +150,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Хемфри Гилберт</Russian>
+		<Russian>Сэр Хемфри Гилберт</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_HUMPHREY_GILBERT_PEDIA</Tag>
@@ -345,7 +345,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Джон Харви</Russian>
+		<Russian>Сэр Джон Харви</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_SIR_JOHN_HARVEY_PEDIA</Tag>

--- a/Assets/XML/Text/XML_AUTO_UTF8_FatherInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_FatherInfo.xml
@@ -1024,7 +1024,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Фрэнсис Дрейк</Russian>
+		<Russian>Сэр Фрэнсис Дрейк</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_FRANCIS_DRAKE_PEDIA</Tag>
@@ -1523,7 +1523,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Уильям Пенн</Russian>
+		<Russian>Сэр Уильям Пенн</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_ADMIRAL_WILLIAM_PENN_PEDIA</Tag>
@@ -1640,7 +1640,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Джеймс Ланкастер</Russian>
+		<Russian>Сэр Джеймс Ланкастер</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_JAMES_LANCASTER_PEDIA</Tag>
@@ -4005,7 +4005,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Уолтер Рэли</Russian>
+		<Russian>Сэр Уолтер Рэли</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_FATHER_WALTER_RALEIGH_PEDIA</Tag>

--- a/Assets/XML/Text/XML_AUTO_UTF8_TraitInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_TraitInfo.xml
@@ -999,7 +999,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Фрэнсис Дрейк</Russian>
+		<Russian>Сэр Фрэнсис Дрейк</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_TRAIT_FRIEDRICH_WILHELM_VON_STEUBEN</Tag>
@@ -1369,7 +1369,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Уильям Пенн</Russian>
+		<Russian>Сэр Уильям Пенн</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_TRAIT_OTTO_FRIEDRICH_VON_DER_GROEBEN</Tag>
@@ -1485,7 +1485,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Джеймс Ланкастер</Russian>
+		<Russian>Сэр Джеймс Ланкастер</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_TRAIT_HENRY_SHRAPNEL</Tag>
@@ -2033,7 +2033,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Хемфри Гилберт</Russian>
+		<Russian>Сэр Хемфри Гилберт</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_TRAIT_JOHN_SMITH</Tag>
@@ -3509,7 +3509,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Уолтер Рэли</Russian>
+		<Russian>Сэр Уолтер Рэли</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_VELAZQUEZ_DE_CUELLAR</Tag>
@@ -3625,7 +3625,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Томас Гейтс</Russian>
+		<Russian>Сэр Томас Гейтс</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_TRAIT_ROBERT_BAKEWELL</Tag>
@@ -3770,7 +3770,7 @@
 			<Gender>Male</Gender>
 			<Plural>0</Plural>
 		</Spanish>
-		<Russian>Джон Харви</Russian>
+		<Russian>Сэр Джон Харви</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_TRAIT_JOHN_MAURICE</Tag>


### PR DESCRIPTION
The prefixes are missing in this translation alone, despite there being no rule in the language about this, and in my opinion that deprives players of quite of a bit of flavor.