### PR TITLE
possible fix for issue #1124

### DIFF
--- a/Assets/XML/Buildings/CIV4BuildingInfos.xml
+++ b/Assets/XML/Buildings/CIV4BuildingInfos.xml
@@ -3128,7 +3128,7 @@
 			<FreePromotion>NONE</FreePromotion>
 			<bGraphicalOnly>0</bGraphicalOnly>
 			<bWorksWater>0</bWorksWater>
-			<bWater>1</bWater>
+			<bWater>0</bWater>
 			<bRiver>0</bRiver>
 			<bCapital>0</bCapital>
 			<bNationalWonder>0</bNationalWonder>
@@ -3227,7 +3227,7 @@
 			<FreePromotion>NONE</FreePromotion>
 			<bGraphicalOnly>0</bGraphicalOnly>
 			<bWorksWater>0</bWorksWater>
-			<bWater>1</bWater>
+			<bWater>0</bWater>
 			<bRiver>0</bRiver>
 			<bCapital>0</bCapital>
 			<bNationalWonder>0</bNationalWonder>


### PR DESCRIPTION
The Civ4BuildingInfos.xml clearly states that the pier/dock can be built next to lakes, but the flag <bWater>1</bWater> forbids building around river/lakes.

At first view, the simplest solution is to say that piers/docks has bWater set to 0.