### PR TITLE
Fix event random numbers never stored in setRandomNumbers()

### DIFF
--- a/Project Files/DLLSources/Events/EventTrigger.cpp
+++ b/Project Files/DLLSources/Events/EventTrigger.cpp
@@ -71,6 +71,7 @@ void EventTriggeredData::setRandomNumbers()
 			RandomContainer container;
 			container.event = eEvent;
 			container.number = GC.getGameINLINE().getSorenRandNum(1000, "Event random number");
+			m_RandomNumbers.push_back(container);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `EventTriggeredData::setRandomNumbers()` creates a `RandomContainer` for each event, generates a random number, but never calls `m_RandomNumbers.push_back(container)` — the vector stays empty
- This causes `getRandomNumber()` and `getRandomNumberForIndex()` to always return 0 (the fallback default)
- All probability checks using these functions become no-ops (e.g., `canTriggerVolcanoDormant1` fires 100% instead of ~25%)

## Details

The bug affects two code paths:

1. **Python callbacks** using `getRandomNumberForIndex()` — e.g., the volcano dormant event always triggers because `0 < 250` is always true
2. **DLL-side `TriggerChance` fastpath** in `CvPlayer::canDoEvent()` which uses `getRandomNumber(eEvent)` — always returns 0, bypassing probability gates

The fix is a single missing `push_back` call.

## Test plan

- [ ] Start a game with a volcano on the map; verify the dormant event doesn't fire every single time
- [ ] Verify events using `TriggerChance` fire at their intended probability rather than always/never

Related: #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)