### PR TITLE
Fix m_iPlotX used for both X and Y in initTriggeredData

### DIFF
--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -14402,7 +14402,7 @@ EventTriggeredData* CvPlayer::initTriggeredData(EventTriggerTypes eEventTrigger,
 				return NULL;
 			}
 
-			Coordinates coord (pTriggerData->m_iPlotX, pTriggerData->m_iPlotX);
+			Coordinates coord (pTriggerData->m_iPlotX, pTriggerData->m_iPlotY);
 
 			// python may change pTriggerData
 			pCity = getCity(pTriggerData->m_iCityId);


### PR DESCRIPTION
## Summary

- In `CvPlayer::initTriggeredData()`, after a `PythonCanDo` callback returns, the code reconstructs plot coordinates from the trigger data (since Python may have modified them)
- Line 14416 passes `m_iPlotX` as both arguments: `Coordinates coord(pTriggerData->m_iPlotX, pTriggerData->m_iPlotX)`
- This resolves to plot (X, X) instead of (X, Y), causing the event to target the wrong map tile

## Details

The bug only manifests when a `PythonCanDo` callback modifies the trigger's plot coordinates and X != Y. In that case, all subsequent logic using `pPlot` (text generation, world news, event application) operates on the wrong tile.

Events where `PythonCanDo` does not modify coordinates are unaffected since `pPlot` was already correctly set before the callback.

Copy-paste typo fix: `m_iPlotX` → `m_iPlotY` for the second argument.

## Test plan

- [ ] Verify events with plot-modifying Python callbacks target the correct map tile
- [ ] Code review: confirm no other instances of this pattern exist (grep confirmed none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)