### PR TITLE
Fix remote crash from negative PlayerTypes in CvNetwork::receive()

### DIFF
--- a/Project Files/DLLSources/Network/CvNetwork.cpp
+++ b/Project Files/DLLSources/Network/CvNetwork.cpp
@@ -55,6 +55,11 @@ void CvNetwork::addToVector(const int (&data)[CvNetwork::iPacketSize])
 // upon receipt of a packet by the exe.
 void CvNetwork::receive(PlayerTypes ePlayer, const int (&data)[CvNetwork::iPacketSize])
 {
+	if (ePlayer < 0 || ePlayer >= MAX_PLAYERS)
+	{
+		return;
+	}
+
 	if (ePlayer < receiving_vector.size() && receiving_vector[ePlayer] != NULL)
 	{
 		// already receiving a multi part message


### PR DESCRIPTION
## Summary
- Adds a bounds check at the top of `CvNetwork::receive()` to reject invalid player IDs (`< 0` or `>= MAX_PLAYERS`) before they reach the signed-to-unsigned comparison with `vector::size()`
- Without this check, a negative `ePlayer` (e.g. `NO_PLAYER = -1`) is implicitly cast to `~4 billion` when compared to the unsigned `size_t`, causing an infinite `push_back` loop that exhausts the 32-bit address space and crashes the game

Fixes #1225

## Test plan
- [ ] Verify multiplayer games still function normally (valid player IDs unaffected by the early return)
- [ ] Confirm the fix compiles cleanly in Assert, Release, and FinalRelease targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)