### PR TITLE
Fix undefined behavior: SAFE_DELETE_ARRAY on scalar new in CvNetwork

### DIFF
--- a/Project Files/DLLSources/Network/CvNetwork.cpp
+++ b/Project Files/DLLSources/Network/CvNetwork.cpp
@@ -75,7 +75,7 @@ void CvNetwork::receive(PlayerTypes ePlayer, const int (&data)[CvNetwork::iPacke
 		// single part message
 		// execute and release memory
 		receiving_vector[ePlayer]->unpack();
-		SAFE_DELETE_ARRAY(receiving_vector[ePlayer]);
+		SAFE_DELETE(receiving_vector[ePlayer]);
 	}
 }
 
@@ -93,7 +93,7 @@ void CvNetwork::reset()
 {
 	for (unsigned int i = 0; i < receiving_vector.size(); ++i)
 	{
-		SAFE_DELETE_ARRAY(receiving_vector[i]);
+		SAFE_DELETE(receiving_vector[i]);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Changes `SAFE_DELETE_ARRAY` to `SAFE_DELETE` on lines 78 and 96 of `CvNetwork.cpp`
- Network message objects are allocated with scalar `new` via `createReceivedMessage()` but were freed with `SAFE_DELETE_ARRAY` (`delete[]`), which is undefined behavior per C++ §5.3.5/2
- This UB executes on every received network packet in multiplayer, risking heap corruption under different allocator/compiler configurations

Fixes #1226

## Test plan
- [ ] Verify multiplayer packet handling still works correctly (send/receive messages between players)
- [ ] Confirm the fix compiles cleanly in Assert, Release, and FinalRelease targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)