### PR TITLE
Clamp enumByteSize read count to prevent global buffer overflow

### DIFF
--- a/Project Files/DLLSources/CvSavegame.cpp
+++ b/Project Files/DLLSources/CvSavegame.cpp
@@ -162,6 +162,10 @@ CvSavegameReader::CvSavegameReader(CvSavegameReaderBase& readerBase)
 			// read the class enum sizes
 			byte iSize;
 			Read(iSize);
+			if (iSize > NUM_SAVEGAME_CLASS_TYPES)
+			{
+				iSize = NUM_SAVEGAME_CLASS_TYPES;
+			}
 			for (int i = 0; i < iSize; ++i)
 			{
 				Read(enumByteSize[i]);


### PR DESCRIPTION
## Summary
- Clamps the `iSize` byte read from the savegame to `NUM_SAVEGAME_CLASS_TYPES` (23) before using it as a loop bound for writing into the `enumByteSize` global array
- Without this check, a crafted savegame sets `iSize` up to 255, overwriting 232 bytes of adjacent globals — including the conversion table that controls all subsequent deserialization

Fixes #1229

## Test plan
- [ ] Load an existing savegame — verify it loads identically to before
- [ ] Save and reload mid-game — verify no data loss
- [ ] Confirm the fix compiles cleanly in Assert, Release, and FinalRelease targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)