### PR TITLE
Add default case to all savegame tag switches to prevent parser desync

### DIFF
--- a/Project Files/DLLSources/CvAreaSavegame.cpp
+++ b/Project Files/DLLSources/CvAreaSavegame.cpp
@@ -159,6 +159,10 @@ void CvArea::read(CvSavegameReader reader)
 			case Save_END:
 				bContinue = false;
 				break;
+			default:
+				FAssertMsg(false, "Unhandled savegame enum");
+				bContinue = false;
+				break;
 
 		}
 	}

--- a/Project Files/DLLSources/CvCityAISavegame.cpp
+++ b/Project Files/DLLSources/CvCityAISavegame.cpp
@@ -193,7 +193,10 @@ void CvCityAI::read(CvSavegameReader reader)
 			case CitySaveAi_BestBuildValue                      : reader.Read(m_em_iBestBuildValue)                              ; break;
 			case CitySaveAi_BestBuild                           : reader.Read(m_em_eBestBuild)                                   ; break; 
 
-			default: FAssert(false);
+			default:
+				FAssert(false);
+				bContinue = false;
+				break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvCitySavegame.cpp
+++ b/Project Files/DLLSources/CvCitySavegame.cpp
@@ -592,6 +592,10 @@ void CvCity::read(CvSavegameReader reader)
 
 		case CitySave_Oppressometer                              : reader.Discard<int>()                                    ; break;
 		case CitySave_OppressometerGrowthModifier                : reader.Discard<int>()                                    ; break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 

--- a/Project Files/DLLSources/CvDealSavegame.cpp
+++ b/Project Files/DLLSources/CvDealSavegame.cpp
@@ -80,7 +80,10 @@ void CvDeal::read(CvSavegameReader reader)
 		case DealSave_SecondPlayer: reader.Read(m_eSecondPlayer); break;
 		case DealSave_firstTrades: reader.Read(m_firstTrades); break;
 		case DealSave_secondTrades: reader.Read(m_secondTrades); break;
-		
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 
 		}
 		

--- a/Project Files/DLLSources/CvGameAISavegame.cpp
+++ b/Project Files/DLLSources/CvGameAISavegame.cpp
@@ -59,6 +59,10 @@ void CvGameAI::read(CvSavegameReader reader)
 		{
 		case GameSaveAI_END: bContinue = false; break;
 		case GameSaveAI_Pad: reader.Read(m_iPad); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvGameSavegame.cpp
+++ b/Project Files/DLLSources/CvGameSavegame.cpp
@@ -340,6 +340,10 @@ void CvGame::read(CvSavegameReader reader)
 		case GameSave_CultureVictoryCultureLevel: reader.Read(m_eCultureVictoryCultureLevel); break;
 		case GameSave_WorldBuilderUseCount: reader.Read(m_uiWorldBuilderUseCount); break;
 		case GameSave_AsyncRand: reader.Read(m_em_AsyncRand); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 		
 	}

--- a/Project Files/DLLSources/CvMapSavegame.cpp
+++ b/Project Files/DLLSources/CvMapSavegame.cpp
@@ -141,6 +141,7 @@ void CvMap::read(CvSavegameReader reader)
 
 		default:
 			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
 			break;
 		}
 	}

--- a/Project Files/DLLSources/CvPlayerAISavegame.cpp
+++ b/Project Files/DLLSources/CvPlayerAISavegame.cpp
@@ -288,6 +288,10 @@ void CvPlayerAI::read(CvSavegameReader reader)
 		case PlayerSaveAI_Emotions: reader.Read(m_em_iEmotions); break;
 		case PlayerSaveAI_StrategyStartedTurn: reader.Read(m_em_iStrategyStartedTurn); break;
 		case PlayerSaveAI_StrategyData: reader.Read(m_em_iStrategyData); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvPlayerSavegame.cpp
+++ b/Project Files/DLLSources/CvPlayerSavegame.cpp
@@ -985,6 +985,10 @@ void CvPlayer::read(CvSavegameReader reader)
 			// This will make it adapt to changed xml settings.
 			CivEffect().rebuildCivEffectCache();
 			break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 

--- a/Project Files/DLLSources/CvPlotSavegame.cpp
+++ b/Project Files/DLLSources/CvPlotSavegame.cpp
@@ -372,6 +372,7 @@ void CvPlot::read(CvSavegameReader reader)
 
 		default:
 			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
 			break;
 		}
 	}

--- a/Project Files/DLLSources/CvPopupInfoSavegame.cpp
+++ b/Project Files/DLLSources/CvPopupInfoSavegame.cpp
@@ -117,7 +117,10 @@ void CvPopupInfo::read(CvSavegameReader reader)
 		case PopupInfoSave_OnClickedPythonCallback: reader.Read(m_szOnClickedPythonCallback); break;
 		case PopupInfoSave_PythonModule: reader.Read(m_szPythonModule); break;
 		case PopupInfoSave_PythonButtons: reader.Read(m_aPythonButtons); break;
-		
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvReplayMessageSavegame.cpp
+++ b/Project Files/DLLSources/CvReplayMessageSavegame.cpp
@@ -89,7 +89,10 @@ void CvReplayMessage::read(CvSavegameReader reader)
 		case ReplayMessageSave_Player: reader.Read(m_ePlayer); break;
 		case ReplayMessageSave_Text: reader.Read(m_szText); break;
 		case ReplayMessageSave_Color: reader.Read(m_eColor); break;
-		
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 
 		}
 		

--- a/Project Files/DLLSources/CvSelectionGroupAISavegame.cpp
+++ b/Project Files/DLLSources/CvSelectionGroupAISavegame.cpp
@@ -93,6 +93,10 @@ void CvSelectionGroupAI::read(CvSavegameReader reader)
 		case SelectionGroupAISave_GroupAttack: reader.Read(m_bGroupAttack); break;
 		case SelectionGroupAISave_GroupAttackX: reader.Read(m_iGroupAttackX); break;
 		case SelectionGroupAISave_GroupAttackY: reader.Read(m_iGroupAttackY); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvSelectionGroupSavegame.cpp
+++ b/Project Files/DLLSources/CvSelectionGroupSavegame.cpp
@@ -103,9 +103,13 @@ void CvSelectionGroup::read(CvSavegameReader reader)
 				m_aTradeRoutes.insert(iRouteID);
 			}
 			break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
-	
+
 }
 
 void CvSelectionGroup::write(CvSavegameWriter writer)

--- a/Project Files/DLLSources/CvTalkingHeadMessageSavegame.cpp
+++ b/Project Files/DLLSources/CvTalkingHeadMessageSavegame.cpp
@@ -120,7 +120,10 @@ void CvTalkingHeadMessage::read(CvSavegameReader reader)
 		case TalkingHeadMessageSave_FromPlayer: reader.Read(m_eFromPlayer); break;
 		case TalkingHeadMessageSave_Target: reader.Read(m_eTarget); break;
 		case TalkingHeadMessageSave_Shown: reader.Read(m_bShown); break;
-
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvTeamAISavegame.cpp
+++ b/Project Files/DLLSources/CvTeamAISavegame.cpp
@@ -124,6 +124,10 @@ void CvTeamAI::read(CvSavegameReader reader)
 
 		case TeamAISave_WarPlan: reader.Read(m_em_eWarPlan); break;
 		case TeamAISave_WorstEnemy: reader.Read(m_eWorstEnemy); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvTeamSavegame.cpp
+++ b/Project Files/DLLSources/CvTeamSavegame.cpp
@@ -183,6 +183,10 @@ void CvTeam::read(CvSavegameReader reader)
 		case TeamSave_EuropeUnitsPurchased: reader.Read(m_em_iEuropeUnitsPurchased); break;
 
 		case TeamSave_RevealedBonuses: reader.Read(m_aeRevealedBonuses); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvTradeRouteGroupSavegame.cpp
+++ b/Project Files/DLLSources/CvTradeRouteGroupSavegame.cpp
@@ -67,7 +67,10 @@ void CvTradeRouteGroup::read(CvSavegameReader reader)
 		case TradeRouteGroupSave_Id: reader.Read(m_iId); break;
 		case TradeRouteGroupSave_Name: reader.Read(m_sName); break;
 		case TradeRouteGroupSave_Routes: reader.Read(m_Routes); break;
-
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvTradeRouteSavegame.cpp
+++ b/Project Files/DLLSources/CvTradeRouteSavegame.cpp
@@ -71,7 +71,10 @@ void CvTradeRoute::read(CvSavegameReader reader)
 		case TradeRouteSave_SourceCity: reader.Read(m_kSourceCity); break;
 		case TradeRouteSave_DestinationCity: reader.Read(m_kDestinationCity); break;
 		case TradeRouteSave_Yield : reader.Read(m_eYield); break;
-
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvUnitAISavegame.cpp
+++ b/Project Files/DLLSources/CvUnitAISavegame.cpp
@@ -93,6 +93,10 @@ void CvUnitAI::read(CvSavegameReader reader)
 		case UnitSaveAI_OldProfession: reader.Read(m_eOldProfession); break;
 		case UnitSaveAI_IdealProfessionCache: reader.Read(m_eIdealProfessionCache); break;
 		case UnitSaveAI_AutomatedAbortTurn: reader.Read(m_iAutomatedAbortTurn); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 	

--- a/Project Files/DLLSources/CvUnitSavegame.cpp
+++ b/Project Files/DLLSources/CvUnitSavegame.cpp
@@ -369,6 +369,10 @@ void CvUnit::read(CvSavegameReader reader)
 
 		case UnitSave_AllowDangerousPath: reader.Read(m_bAllowDangerousPath); break;
 		case UnitSave_AllowDirectPath: reader.Read(m_bAllowDirectPath); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 	}
 

--- a/Project Files/DLLSources/Events/EventTriggerSavegame.cpp
+++ b/Project Files/DLLSources/Events/EventTriggerSavegame.cpp
@@ -133,6 +133,10 @@ void EventTriggeredData::read(CvSavegameReader& reader)
 		case EventTrigger_szText: reader.Read(m_szText); break;
 		case EventTrigger_szGlobalText: reader.Read(m_szGlobalText); break;
 		case EventTrigger_RandomNumberVector: reader.Read(m_RandomNumbers); break;
+		default:
+			FAssertMsg(false, "Unhandled savegame enum");
+			bContinue = false;
+			break;
 		}
 
 	}


### PR DESCRIPTION
## Summary
- Adds `default: bContinue = false; break;` to 19 savegame switch statements that had no default case
- Adds `bContinue = false;` to 3 existing default cases that only had FAssert (stripped in Release builds)
- Without this, an unrecognized tag value leaves its data bytes unconsumed, permanently misaligning the parser — a crafted savegame exploits this to inject controlled values into arbitrary game state fields

**22 files touched** — all `*Savegame.cpp` files with tag-reading switch statements.

Fixes #1230

## Test plan
- [ ] Load an existing savegame — verify it loads identically to before (no false positives from the default case)
- [ ] Save and reload mid-game — verify no data loss
- [ ] In Assert build: verify no FAssert fires during normal save/load (confirms no legitimate tag hits the default)
- [ ] Confirm the fix compiles cleanly in Assert, Release, and FinalRelease targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)