### PR TITLE
Return -1 instead of raw index when ConvertIndex lookup fails

### DIFF
--- a/Project Files/DLLSources/CvSavegame.cpp
+++ b/Project Files/DLLSources/CvSavegame.cpp
@@ -539,7 +539,7 @@ int CvSavegameReader::ConvertIndex(JITarrayTypes eType, int iIndex) const
 		}
 	}
 
-	return iIndex;
+	return -1;
 }
 
 int CvSavegameReader::GetXmlSize(JITarrayTypes eType) const


### PR DESCRIPTION
## Summary
- Changes `ConvertIndex()` to return -1 (the established "removed entry" sentinel) when a savegame enum index exceeds the conversion table size, instead of passing through the raw attacker-controlled index
- Without this, an out-of-range index passes through to `EnumMap::set()` where the bounds check (`FAssert`) is stripped in Release builds, enabling out-of-bounds writes into game object memory

Fixes #1231

## Test plan
- [ ] Load an existing savegame — verify it loads identically to before
- [ ] Load a savegame from an older version with different XML content — verify conversion still works correctly for valid indices
- [ ] Save and reload mid-game — verify no data loss
- [ ] Confirm the fix compiles cleanly in Assert, Release, and FinalRelease targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)