### PR TITLE
Fix city title-bar hover and expand yield/health tooltips

### DIFF
--- a/Assets/Python/Screens/CvMainInterface.py
+++ b/Assets/Python/Screens/CvMainInterface.py
@@ -545,6 +545,12 @@ class CvMainInterface:
 			size = 4
 		return "<font=" + str(size) + ">" + Text + "</font>"
 
+	def setTitleBarHelpText( self, screen, name, szBuffer, x, widgetType, data1, data2 = -1 ):
+		# setText + stone style matches PopulationText. Use only at X positions outside the 3D city view.
+		screen.setText(name, "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, x, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, widgetType, data1, data2)
+		screen.setStyle(name, "Button_Stone_Style")
+		screen.show(name)
+
 	# Will Initialize the majority of Background panels and Widgets
 	def interfaceScreen ( self ):
 		if (CyGame().isPitbossHost()):
@@ -572,6 +578,8 @@ class CvMainInterface:
 	# CITY BURLAP BACKGROUND PANELS
 		screen.addPanel("CityTopBackground", u"", u"", True, False, 0, 0, xResolution, CITY_TITLE_BAR_HEIGHT, PanelStyles.PANEL_STYLE_STANDARD, WidgetTypes.WIDGET_GENERAL, -1, -1 )
 		screen.addDrawControl("CityTopBackground", ArtFileMgr.getInterfaceArtInfo("INTERFACE_CITY_BG_TOP").getPath(), 0, 0, xResolution, CITY_TITLE_BAR_HEIGHT, WidgetTypes.WIDGET_GENERAL, -1, -1 )
+		# Title-bar art is transparent over the 3D city view, so default hit-test lets terrain steal hover.
+		screen.setHitTest("CityTopBackground", HitTestTypes.HITTEST_SOLID)
 		self.appendtoHideState(screen, "CityTopBackground", HIDE_TYPE_CITY, HIDE_LEVEL_ALL)
 
 		screen.addPanel("CityLeftBackground", u"", u"", True, False, 0, CITY_TITLE_BAR_HEIGHT, CITIZEN_BAR_WIDTH, yResolution, PanelStyles.PANEL_STYLE_STANDARD, WidgetTypes.WIDGET_GENERAL, -1, -1 )
@@ -1136,13 +1144,13 @@ class CvMainInterface:
 
 	# CITY AND PLOT SCROLL BUTTONS
 		ScrollButtonSize = MEDIUM_BUTTON_SIZE
-		# R&R, Robert Surcouf Screen Resolution/Ratio - Start
-		#iXmodifier = xResolution * 5 / 100 - (xResolution - 1000)/200 					# More or less: 1024 -> 5% 1280 -> 4% / 1600 -> 2% / 1980 -> 0%
-		#screen.setImageButton("CityScrollMinus",ArtFileMgr.getInterfaceArtInfo("INTERFACE_CITY_LEFT_ARROW").getPath(), (xResolution * 35 / 100) - (ScrollButtonSize / 2), (STACK_BAR_HEIGHT / 2) - (ScrollButtonSize / 3), ScrollButtonSize, ScrollButtonSize, WidgetTypes.WIDGET_CITY_SCROLL, -1, -1)
-		screen.setImageButton("CityScrollMinus",ArtFileMgr.getInterfaceArtInfo("INTERFACE_CITY_LEFT_ARROW").getPath(), (xResolution * 35 / 100) - (ScrollButtonSize / 2) +xResolution * 5 / 100 - (xResolution - 1000)/200 , (STACK_BAR_HEIGHT / 2) - (ScrollButtonSize / 3), ScrollButtonSize, ScrollButtonSize, WidgetTypes.WIDGET_CITY_SCROLL, -1, -1)
+		# Sit next to the city name so the left title-bar stats have room.
+		iNameCenter = xResolution / 2
+		iNameHalfWidth = max(70, xResolution * 5 / 100)
+		iArrowY = (STACK_BAR_HEIGHT / 2) - (ScrollButtonSize / 3)
+		screen.setImageButton("CityScrollMinus", ArtFileMgr.getInterfaceArtInfo("INTERFACE_CITY_LEFT_ARROW").getPath(), iNameCenter - iNameHalfWidth - ScrollButtonSize - 6, iArrowY, ScrollButtonSize, ScrollButtonSize, WidgetTypes.WIDGET_CITY_SCROLL, -1, -1)
 		self.appendtoHideState(screen, "CityScrollMinus", HIDE_TYPE_CITY, HIDE_LEVEL_HIDE)
-		#screen.setImageButton("CityScrollPlus",ArtFileMgr.getInterfaceArtInfo("INTERFACE_CITY_RIGHT_ARROW").getPath(), (xResolution * 65 / 100) - (ScrollButtonSize / 2), (STACK_BAR_HEIGHT / 2) - (ScrollButtonSize / 3), ScrollButtonSize, ScrollButtonSize, WidgetTypes.WIDGET_CITY_SCROLL, 1, -1)
-		screen.setImageButton("CityScrollPlus",ArtFileMgr.getInterfaceArtInfo("INTERFACE_CITY_RIGHT_ARROW").getPath(), (xResolution * 65 / 100) - (ScrollButtonSize / 2)-xResolution * 5 / 100 - (xResolution - 1000)/200 , (STACK_BAR_HEIGHT / 2) - (ScrollButtonSize / 3), ScrollButtonSize, ScrollButtonSize, WidgetTypes.WIDGET_CITY_SCROLL, 1, -1)
+		screen.setImageButton("CityScrollPlus", ArtFileMgr.getInterfaceArtInfo("INTERFACE_CITY_RIGHT_ARROW").getPath(), iNameCenter + iNameHalfWidth + 6, iArrowY, ScrollButtonSize, ScrollButtonSize, WidgetTypes.WIDGET_CITY_SCROLL, 1, -1)
 		self.appendtoHideState(screen, "CityScrollPlus", HIDE_TYPE_CITY, HIDE_LEVEL_HIDE)
 		# R&R, Robert Surcouf Screen Resolution/Ratio - End
 
@@ -2515,6 +2523,28 @@ class CvMainInterface:
 						screen.hide("CityScrollMinus")
 						screen.hide("CityScrollPlus")
 
+			# Title-bar columns. Do not place widgets over the 3D city view (it steals hover).
+				iMapRight = CITIZEN_BAR_WIDTH + CITY_VIEW_BOX_HEIGHT_AND_WIDTH - (MAP_EDGE_MARGIN_WIDTH * 2)
+				iPopX = MEDIUM_BUTTON_SIZE + 8
+				iPopWidth = max(155, xResolution * 9 / 100)
+				iStep = max(46, xResolution * 26 / 1000)
+				iHammerX = iPopX + iPopWidth
+				iLibertyX = iHammerX + iStep
+				iCrossesX = iLibertyX + iStep
+				iEducationX = iCrossesX + iStep
+				iCultureX = iEducationX + iStep + 62
+				iTotalLawX = iCultureX + 128
+				iLawX = iTotalLawX + ((iStep * 2) / 3)
+				iCrimeX = iLawX + ((iStep * 2) / 3)
+				iTotalHappinessX = iCrimeX + 48
+				iHappinessX = iTotalHappinessX + 36
+				iUnhappinessX = iHappinessX + 26
+				iHealthX = iMapRight + 24
+				iHarbourX = iHealthX + 50
+				iBarracksX = iHarbourX + 28
+				iDefenseX = iBarracksX + 36
+				iStorageX = xResolution - 58
+
 			# CITY NAME HEADER
 				szBuffer = u"<font=4>"
 				if (pHeadSelectedCity.isCapital()):
@@ -2541,7 +2571,7 @@ class CvMainInterface:
 				else:
 					szBuffer = localText.getText("INTERFACE_CITY_STAGNANT", ())
 				szBuffer += u"</font>"
-				screen.setText("PopulationText", "Background", szBuffer, CvUtil.FONT_LEFT_JUSTIFY, xResolution * 4 / 100, CITY_TITLE_BAR_HEIGHT / 8, -0.3, FontTypes.GAME_FONT, WidgetTypes.WIDGET_HELP_POPULATION, -1, -1 )
+				screen.setText("PopulationText", "Background", szBuffer, CvUtil.FONT_LEFT_JUSTIFY, iPopX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.GAME_FONT, WidgetTypes.WIDGET_HELP_POPULATION, -1, -1 )
 				screen.setStyle("PopulationText", "Button_Stone_Style")
 
 			# CURRENT PRODUCTION BAR FILL
@@ -2614,9 +2644,6 @@ class CvMainInterface:
 						screen.changeImageButton("CityBuildingGraphic" + str(iSpecial), szTexture)
 						screen.show("CityBuildingGraphic" + str(iSpecial))
 
-				# More or less: 1024 -> 5% 1280 -> 4% / 1600 -> 2% / 1980 -> 0%
-				iXmodifier = max(xResolution * 5 / 100 - (xResolution - 1000)/200 , 0)
-
 			# CITIY DEFENSE MODIFIER
 				iDefenseModifier = pHeadSelectedCity.getDefenseModifier()
 				if (iDefenseModifier != 0):
@@ -2625,34 +2652,41 @@ class CvMainInterface:
 						szTempBuffer = u" (%d%%)" %(( ( gc.getMAX_CITY_DEFENSE_DAMAGE() - pHeadSelectedCity.getDefenseDamage() ) * 100 ) / gc.getMAX_CITY_DEFENSE_DAMAGE() )
 						szBuffer = szBuffer + szTempBuffer
 					szBuffer = "<font=3>" + szBuffer + "</font>"
-					screen.setLabel("DefenseText", "Background", szBuffer, CvUtil.FONT_RIGHT_JUSTIFY, xResolution * 89 / 100 -iXmodifier , CITY_TITLE_BAR_HEIGHT / 8, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_DEFENSE, -1, -1 )
-					screen.show("DefenseText")
+					self.setTitleBarHelpText(screen, "DefenseText", szBuffer, iDefenseX, WidgetTypes.WIDGET_HELP_DEFENSE, -1)
 
 			# CITY HAMMER PRODUCTION
 				iHammers = pHeadSelectedCity.getCurrentProductionDifference(True)
 				szBuffer = u"<font=3>" + u"%i%c" % (iHammers, gc.getYieldInfo(YieldTypes.YIELD_HAMMERS).getChar()) + u"</font>"
-				screen.setLabel("HammerText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 11 / 100 +iXmodifier , CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_PRODUCTION_MOD_HELP, -1, -1 )
+				screen.setLabel("HammerText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, iHammerX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_PRODUCTION_MOD_HELP, -1, -1 )
 
 				netYields = list(pHeadSelectedCity.calculateNetYieldList())
 			# CITY LIBERTYBELL PRODUCTION
 				iLiberty = netYields[YieldTypes.YIELD_BELLS]
 				szBuffer = u"<font=3>" + u"%i%c" % (iLiberty, gc.getYieldInfo(YieldTypes.YIELD_BELLS).getChar()) + u"</font>"
-				screen.setLabel("LibertyText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 14 / 100 +iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_BELLS, -1 )
+				screen.setLabel("LibertyText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, iLibertyX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_BELLS, -1 )
 
 			# CITY CROSS PRODUCTION
 				iCrosses = netYields[YieldTypes.YIELD_CROSSES]
 				szBuffer = u"<font=3>" + u"%i%c" % (iCrosses, gc.getYieldInfo(YieldTypes.YIELD_CROSSES).getChar()) + u"</font>"
-				screen.setLabel("CrossesText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 17 / 100 +iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_CROSSES, -1 )
+				screen.setLabel("CrossesText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, iCrossesX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_CROSSES, -1 )
 
 			# CITY EDUCATION PRODUCTION
 				iBooks = netYields[YieldTypes.YIELD_EDUCATION]
 				szBuffer = u"<font=3>" + u"%i%c" % (iBooks, gc.getYieldInfo(YieldTypes.YIELD_EDUCATION).getChar()) + u"</font>"
-				screen.setLabel("EducationText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 20 / 100 +iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_EDUCATION, -1 )
+				screen.setLabel("EducationText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, iEducationX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_EDUCATION, -1 )
 
 			# CITY Culture PRODUCTION
-				iCulture = pHeadSelectedCity.getCultureRate() # RaR, ray, small correction
-				szBuffer = u"<font=3>" + u"%i%c" % (iCulture, gc.getYieldInfo(YieldTypes.YIELD_CULTURE).getChar()) + u"</font>"
-				screen.setLabel("CultureText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 23 / 100 +iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_CULTURE, -1 )
+				iCultureRate = pHeadSelectedCity.getCultureRate()
+				iCultureStored = pHeadSelectedCity.getCulture(pHeadSelectedCity.getOwner())
+				iCultureThreshold = pHeadSelectedCity.getCultureThreshold()
+				szBuffer = u"<font=3>%d%c %d/%d" % (iCultureRate, gc.getYieldInfo(YieldTypes.YIELD_CULTURE).getChar(), iCultureStored, iCultureThreshold)
+				if iCultureRate > 0 and iCultureThreshold > iCultureStored:
+					iCultureTurns = (iCultureThreshold - iCultureStored + iCultureRate - 1) / iCultureRate
+					if iCultureTurns < 1:
+						iCultureTurns = 1
+					szBuffer += u" " + localText.getText("INTERFACE_CITY_TURNS", (iCultureTurns, ))
+				szBuffer += u"</font>"
+				screen.setLabel("CultureText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, iCultureX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_CULTURE, -1 )
 
 			# CITY HEALTH PRODUCTION
 				#get the coloured string for current City Health
@@ -2682,7 +2716,7 @@ class CvMainInterface:
 
 				#now add them all together and display on top of the Screen
 				szBuffer = szBufferCurrentHealth + szBufferHealthChange +szBufferHealthIcon
-				screen.setLabel("HealthText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 68 / 100 +iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_HEALTH, -1 )
+				self.setTitleBarHelpText(screen, "HealthText", szBuffer, iHealthX, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_HEALTH)
 
 			# CITY HAPPINESS vs UNHAPPINESS
 				pHeadSelectedCity.updateCityHappiness()
@@ -2690,31 +2724,34 @@ class CvMainInterface:
 				iHappiness = pHeadSelectedCity.getCityHappiness()
 				iUnhappiness = pHeadSelectedCity.getCityUnHappiness()
 
+				eTotalHappinessHelp = HELP_TOTAL_HAPPINESS_ZERO
+
 				if iHappiness > iUnhappiness: # Green and we use Icon Happiness
 					iTotalHap = iHappiness - iUnhappiness
 					szBufferTotal = u"<font=3>" + u"<color="u"0,255,0" + u">"+str(iTotalHap) + u"</color>" + u"</font>"
 					szBufferTotal += u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_HAPPINESS).getChar()) + u"</font>"
 					szBufferTotal += u"<font=3>" + u"=" + u"</font>"
-					screen.setLabel("TotalHappinessText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 69 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_HAPPINESS_POSITIVE, -1 )
+					eTotalHappinessHelp = HELP_TOTAL_HAPPINESS_POSITIVE
 				elif iUnhappiness > iHappiness: # Red and we use Icon Unhappiness
 					iTotalUnhap = iUnhappiness - iHappiness
 					szBufferTotal = u"<font=3>" + u"<color="u"255,0,0" + u">"+str(iTotalUnhap) + u"</color>" + u"</font>"
 					szBufferTotal += u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_UNHAPPINESS).getChar()) + u"</font>"
 					szBufferTotal += u"<font=3>" + u"=" + u"</font>"
-					screen.setLabel("TotalHappinessText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 69 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_HAPPINESS_NEGATIVE, -1 )
+					eTotalHappinessHelp = HELP_TOTAL_HAPPINESS_NEGATIVE
 				else: # Yellow and we use Icon Happiness
 					iTotalZeroHap = 0
 					szBufferTotal = u"<font=3>" + u"<color="u"255,255,0" + u">" + str(iTotalZeroHap) + u"</color>" + u"</font>"
 					szBufferTotal += u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_HAPPINESS).getChar()) + u"</font>"
 					szBufferTotal += u"<font=3>" + u"=" + u"</font>"
-					screen.setLabel("TotalHappinessText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 69 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_HAPPINESS_ZERO, -1 )
+					eTotalHappinessHelp = HELP_TOTAL_HAPPINESS_ZERO
+				self.setTitleBarHelpText(screen, "TotalHappinessText", szBufferTotal, iTotalHappinessX, WidgetTypes.WIDGET_GENERAL, eTotalHappinessHelp)
 
 				szBufferHappiness = u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_HAPPINESS).getChar()) + u"</font>"
 				szBufferHappiness += u"<font=3>" + u"-" + u"</font>"
-				screen.setLabel("HappinessText", "Background", szBufferHappiness, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 72 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_HAPPINESS, -1 )
+				self.setTitleBarHelpText(screen, "HappinessText", szBufferHappiness, iHappinessX, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_HAPPINESS)
 
 				szBufferUnHappiness = u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_UNHAPPINESS).getChar()) + u" </font>"
-				screen.setLabel("UnhappinessText", "Background", szBufferUnHappiness, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 74 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_UNHAPPINESS, -1 )
+				self.setTitleBarHelpText(screen, "UnhappinessText", szBufferUnHappiness, iUnhappinessX, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_UNHAPPINESS)
 
 			# CITY LAW vs CRIME
 				pHeadSelectedCity.updateCityLaw()
@@ -2727,26 +2764,26 @@ class CvMainInterface:
 					szBufferTotal = u"<font=3>" + u"<color="u"0,255,0" + u">"+str(iTotalLaw) + u"</color>" + u"</font>"
 					szBufferTotal += u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_LAW).getChar()) + u"</font>"
 					szBufferTotal += u"<font=3>" + u"=" + u"</font>"
-					screen.setLabel("TotalLawText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 37 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_LAW_POSITIVE, -1 )
+					screen.setLabel("TotalLawText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, iTotalLawX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_LAW_POSITIVE, -1 )
 				elif iCrime > iLaw: # Red and we use CRIME Icon
 					iTotalCrime = iCrime - iLaw
 					szBufferTotal = u"<font=3>" + u"<color="u"255,0,0" + u">"+str(iTotalCrime) + u"</color>" + u"</font>"
 					szBufferTotal += u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_CRIME).getChar()) + u"</font>"
 					szBufferTotal += u"<font=3>" + u"=" + u"</font>"
-					screen.setLabel("TotalLawText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 37 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_LAW_NEGATIVE, -1 )
+					screen.setLabel("TotalLawText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, iTotalLawX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_LAW_NEGATIVE, -1 )
 				else: # Yellow and we use LAW Icon
 					iTotalZeroLaw = 0
 					szBufferTotal = u"<font=3>" + u"<color="u"255,255,0" + u">" + str(iTotalZeroLaw) + u"</color>" + u"</font>"
 					szBufferTotal += u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_LAW).getChar()) + u"</font>"
 					szBufferTotal += u"<font=3>" + u"=" + u"</font>"
-					screen.setLabel("TotalLawText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 37 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_LAW_ZERO, -1 )
+					screen.setLabel("TotalLawText", "Background", szBufferTotal, CvUtil.FONT_CENTER_JUSTIFY, iTotalLawX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, HELP_TOTAL_LAW_ZERO, -1 )
 
 				szBufferLaw = u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_LAW).getChar()) + u"</font>"
 				szBufferLaw += u"<font=3>" + u"-" + u"</font>"
-				screen.setLabel("LawText", "Background", szBufferLaw, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 40 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_LAW, -1 )
+				screen.setLabel("LawText", "Background", szBufferLaw, CvUtil.FONT_CENTER_JUSTIFY, iLawX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_LAW, -1 )
 
 				szBufferCrime = u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_CRIME).getChar()) + u" </font>"
-				screen.setLabel("CrimeText", "Background", szBufferCrime, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 42 / 100-iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_CRIME, -1 )
+				screen.setLabel("CrimeText", "Background", szBufferCrime, CvUtil.FONT_CENTER_JUSTIFY, iCrimeX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_YIELD, YieldTypes.YIELD_CRIME, -1 )
 
 			# WTP, ray, new Harbour System - START
 				if (pHeadSelectedCity.bShouldShowCityHarbourSystem()):
@@ -2761,19 +2798,13 @@ class CvMainInterface:
 					if (iUsedHarbourSpace <= iHalfMaxHarbourSpace):
 						#szBuffer = u"<font=3>" + u" <color="u"0,255,0" + u">"+ str(iUsedHarbourSpace) + u"(" + str(iMaxHarbourSpace) + u")" + u"</color>" + u"</font>"
 						szBuffer = u"<font=3>" + (u" %c" % CyGame().getSymbolID(FontSymbols.ANCHOR_CHAR)) + "</font>"
-						screen.setLabel("HarbourText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 81 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_HARBOUR_SYSTEM, NEW_HARBOUR_SYSTEM, -1 )
-
-					# red: the harbour is completely full
 					elif (iUsedHarbourSpace >= iMaxHarbourSpace):
 						#szBuffer = u"<font=3>" + u" <color="u"255,0,0" + u">"+ str(iUsedHarbourSpace) + u"(" + str(iMaxHarbourSpace) + u")" + u"</color>" + u"</font>"
 						szBuffer = u"<font=3>" + (u" %c" % CyGame().getSymbolID(FontSymbols.NO_ANCHOR_CHAR)) + "</font>"
-						screen.setLabel("HarbourText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 81 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_HARBOUR_SYSTEM, NEW_HARBOUR_SYSTEM, -1 )
-
-					# yellow: more than half is full, but not completely
 					else:
 						#szBuffer = u"<font=3>" + u" <color="u"255,255,0" + u">" + str(iUsedHarbourSpace) + u"(" + str(iMaxHarbourSpace) + u")" + u"</color>" + u"</font>"
 						szBuffer = u"<font=3>" + (u" %c" % CyGame().getSymbolID(FontSymbols.ANCHOR_CHAR)) + "</font>"
-						screen.setLabel("HarbourText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 81 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_HARBOUR_SYSTEM, NEW_HARBOUR_SYSTEM, -1 )
+					self.setTitleBarHelpText(screen, "HarbourText", szBuffer, iHarbourX, WidgetTypes.WIDGET_HELP_HARBOUR_SYSTEM, NEW_HARBOUR_SYSTEM)
 
 			# WTP, ray, new Barracks System - START
 				if (pHeadSelectedCity.bShouldShowCityBarracksSystem()):
@@ -2788,19 +2819,13 @@ class CvMainInterface:
 					if (iUsedBarracksSpace <= iHalfMaxBarracksSpace):
 						#szBuffer = u"<font=3>" + u" <color="u"0,255,0" + u">"+ str(iUsedBarracksSpace) + u"(" + str(iMaxBarracksSpace) + u")" + u"</color>" + u"</font>"
 						szBuffer = u"<font=3>" + (u" %c" % CyGame().getSymbolID(FontSymbols.BARRACKS_CHAR)) + "</font>"
-						screen.setLabel("BarracksText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 83 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_BARRACKS_SYSTEM, NEW_BARRACKS_SYSTEM, -1 )
-
-					# red: the barracks are completely full
 					elif (iUsedBarracksSpace >= iMaxBarracksSpace):
 						#szBuffer = u"<font=3>" + u" <color="u"255,0,0" + u">"+ str(iUsedBarracksSpace) + u"(" + str(iMaxBarracksSpace) + u")" + u"</color>" + u"</font>"
 						szBuffer = u"<font=3>" + (u" %c" % CyGame().getSymbolID(FontSymbols.NO_BARRACKS_CHAR)) + "</font>"
-						screen.setLabel("BarracksText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 83 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_BARRACKS_SYSTEM, NEW_BARRACKS_SYSTEM, -1 )
-
-					# yellow: more than half is full, but not completely
 					else:
 						#szBuffer = u"<font=3>" + u" <color="u"255,255,0" + u">" + str(iUsedBarracksSpace) + u"(" + str(iMaxBarracksSpace) + u")" + u"</color>" + u"</font>"
 						szBuffer = u"<font=3>" + (u" %c" % CyGame().getSymbolID(FontSymbols.BARRACKS_CHAR)) + "</font>"
-						screen.setLabel("BarracksText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 83 / 100 -iXmodifier, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_HELP_BARRACKS_SYSTEM, NEW_BARRACKS_SYSTEM, -1 )
+					self.setTitleBarHelpText(screen, "BarracksText", szBuffer, iBarracksX, WidgetTypes.WIDGET_HELP_BARRACKS_SYSTEM, NEW_BARRACKS_SYSTEM)
 
 			# REBEL BAR FILL PERCENTAGE
 				fPercentage = float(pHeadSelectedCity.getRebelPercent() / 100.0)
@@ -2855,7 +2880,9 @@ class CvMainInterface:
 
 				# WTP, ray, adding the Yield Icon for Trade Goods to Storage Capacity
 				szBuffer += u"<font=3>" + u"%c" % (gc.getYieldInfo(YieldTypes.YIELD_TRADE_GOODS).getChar()) + u"</font>"
-				screen.setLabel("StorageCapacityText", "Background", szBuffer, CvUtil.FONT_CENTER_JUSTIFY, xResolution * 90 / 100 , CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, VET_NEW_CAPACITY, -1 )
+				screen.setText("StorageCapacityText", "Background", szBuffer, CvUtil.FONT_RIGHT_JUSTIFY, iStorageX, CITY_TITLE_BAR_HEIGHT / 12, -0.3, FontTypes.SMALL_FONT, WidgetTypes.WIDGET_GENERAL, VET_NEW_CAPACITY, -1 )
+				screen.setStyle("StorageCapacityText", "Button_Stone_Style")
+				screen.show("StorageCapacityText")
 
 			screen.hide("TimeText")
 			screen.hide("GoldText")

--- a/Assets/XML/Text/CIV4GameText_RaR_Release1_utf8.xml
+++ b/Assets/XML/Text/CIV4GameText_RaR_Release1_utf8.xml
@@ -1723,6 +1723,26 @@
 		<Hungarian>a Városnak, ha művelve van : %d1%F2_Icon</Hungarian>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_MISC_HELP_YIELD_PLAYER</Tag>
+		<English>[ICON_BULLET]%D1%%%F2[TAB]from civilization</English>
+		<French>[ICON_BULLET]%D1%%%F2[TAB]de la civilisation</French>
+		<German>[ICON_BULLET]%D1%%%F2[TAB]durch die Zivilisation</German>
+		<Italian>[ICON_BULLET]%D1%%%F2[TAB]dalla civiltà</Italian>
+		<Spanish>[ICON_BULLET]%D1%%%F2[TAB]de la civilización</Spanish>
+		<Russian>[ICON_BULLET]%D1%%%F2[TAB]от цивилизации</Russian>
+		<Hungarian>[ICON_BULLET]%D1%%%F2[TAB]a civilizációból</Hungarian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_MISC_HELP_YIELD_TAX</Tag>
+		<English>[ICON_BULLET]%D1%%%F2[TAB]from tax rate</English>
+		<French>[ICON_BULLET]%D1%%%F2[TAB]du taux d'imposition</French>
+		<German>[ICON_BULLET]%D1%%%F2[TAB]durch den Steuersatz</German>
+		<Italian>[ICON_BULLET]%D1%%%F2[TAB]dalle tasse</Italian>
+		<Spanish>[ICON_BULLET]%D1%%%F2[TAB]del tipo impositivo</Spanish>
+		<Russian>[ICON_BULLET]%D1%%%F2[TAB]от налоговой ставки</Russian>
+		<Hungarian>[ICON_BULLET]%D1%%%F2[TAB]az adókulcsból</Hungarian>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_MISC_HELP_YIELD_HEALTH</Tag>
 		<English>[ICON_BULLET]%D1%%%F2[TAB]from city health</English>
 		<French>[ICON_BULLET]%D1%%%F2[TAB]par la santé de la ville</French>
@@ -1749,6 +1769,46 @@
 		<German>%s1 durch Standort = %d2%F3</German>
 		<Russian>%s1 от расположения города = %d2%F3</Russian>
 		<Hungarian>%s1 a Város Elhelyezkedéséből = %d2%F3</Hungarian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_YIELD_HEALTH_CITY_PLOT_FRESH_WATER</Tag>
+		<English>%s1 from fresh water = %D2%F3</English>
+		<French>%s1 de l'eau douce = %D2%F3</French>
+		<German>%s1 durch Süßwasser = %D2%F3</German>
+		<Italian>%s1 dall'acqua dolce = %D2%F3</Italian>
+		<Spanish>%s1 de agua dulce = %D2%F3</Spanish>
+		<Russian>%s1 от пресной воды = %D2%F3</Russian>
+		<Hungarian>%s1 édesvízből = %D2%F3</Hungarian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_YIELD_HEALTH_CITY_PLOT_COAST</Tag>
+		<English>%s1 from coast = %D2%F3</English>
+		<French>%s1 de la côte = %D2%F3</French>
+		<German>%s1 durch Küste = %D2%F3</German>
+		<Italian>%s1 dalla costa = %D2%F3</Italian>
+		<Spanish>%s1 de la costa = %D2%F3</Spanish>
+		<Russian>%s1 от побережья = %D2%F3</Russian>
+		<Hungarian>%s1 tengerpartból = %D2%F3</Hungarian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_YIELD_HEALTH_CITY_PLOT_HILLS</Tag>
+		<English>%s1 from hills = %D2%F3</English>
+		<French>%s1 des collines = %D2%F3</French>
+		<German>%s1 durch Hügel = %D2%F3</German>
+		<Italian>%s1 dalle colline = %D2%F3</Italian>
+		<Spanish>%s1 de las colinas = %D2%F3</Spanish>
+		<Russian>%s1 от холмов = %D2%F3</Russian>
+		<Hungarian>%s1 dombokból = %D2%F3</Hungarian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_YIELD_HEALTH_CITY_PLOT_BAD_TERRAIN</Tag>
+		<English>%s1 from %s4 = %D2%F3</English>
+		<French>%s1 de %s4 = %D2%F3</French>
+		<German>%s1 durch %s4 = %D2%F3</German>
+		<Italian>%s1 da %s4 = %D2%F3</Italian>
+		<Spanish>%s1 de %s4 = %D2%F3</Spanish>
+		<Russian>%s1 от %s4 = %D2%F3</Russian>
+		<Hungarian>%s1 %s4 terepből = %D2%F3</Hungarian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_YIELD_HEALTH_RESSOURCE_CHANGE</Tag>

--- a/Project Files/DLLSources/CvGameTextMgr.cpp
+++ b/Project Files/DLLSources/CvGameTextMgr.cpp
@@ -8829,7 +8829,9 @@ void CvGameTextMgr::setYieldHelp(CvWStringBuffer &szBuffer, CvCity& city, YieldT
 	// unproduced is lost production due to lack of input yields
 	iModifiedProduction -= iUnproduced;
 
-	if (iBaseProduction != 0)
+	// iBaseProduction is plot-only after the loops above. Buildings and indoor
+	// workers (carpenter, preacher, statesman) still need the % breakdown.
+	if (iModifiedProduction != 0)
 	{
 		int iModifier = setCityYieldModifierString(szBuffer, eYieldType, city);
 		if (iModifier != 100)
@@ -8940,8 +8942,52 @@ void CvGameTextMgr::setYieldHelp(CvWStringBuffer &szBuffer, CvCity& city, YieldT
 	if (eYieldType == YIELD_HEALTH)
 	{
 		// WTP, ray, Health Overhaul - START
-		int iCityHealthChangeFromCentralPlot = city.getCityHealthChangeFromCentralPlot();
-		szBuffer.append(gDLL->getText("TXT_KEY_YIELD_HEALTH_CITY_PLOT_CHANGE", info.getTextKeyWide(), iCityHealthChangeFromCentralPlot, info.getChar()));
+		const CvPlot* pCityCenterPlot = city.plot();
+		bool bLocationBreakdown = false;
+		if (pCityCenterPlot != NULL)
+		{
+			if (pCityCenterPlot->isFreshWater())
+			{
+				szBuffer.append(gDLL->getText("TXT_KEY_YIELD_HEALTH_CITY_PLOT_FRESH_WATER", info.getTextKeyWide(), GC.getSWEET_WATER_CITY_LOCATION_HEALTH_BONUS(), info.getChar()));
+				bLocationBreakdown = true;
+			}
+
+			if (pCityCenterPlot->isCoastalLand())
+			{
+				if (bLocationBreakdown)
+				{
+					szBuffer.append(NEWLINE);
+				}
+				szBuffer.append(gDLL->getText("TXT_KEY_YIELD_HEALTH_CITY_PLOT_COAST", info.getTextKeyWide(), GC.getCOASTAL_CITY_LOCATION_HEALTH_BONUS(), info.getChar()));
+				bLocationBreakdown = true;
+			}
+
+			if (pCityCenterPlot->isHills())
+			{
+				if (bLocationBreakdown)
+				{
+					szBuffer.append(NEWLINE);
+				}
+				szBuffer.append(gDLL->getText("TXT_KEY_YIELD_HEALTH_CITY_PLOT_HILLS", info.getTextKeyWide(), GC.getHILL_CITY_LOCATION_HEALTH_BONUS(), info.getChar()));
+				bLocationBreakdown = true;
+			}
+
+			if (GC.getTerrainInfo(pCityCenterPlot->getTerrainType()).isBadCityLocation())
+			{
+				if (bLocationBreakdown)
+				{
+					szBuffer.append(NEWLINE);
+				}
+				szBuffer.append(gDLL->getText("TXT_KEY_YIELD_HEALTH_CITY_PLOT_BAD_TERRAIN", info.getTextKeyWide(), -GC.getBAD_CITY_LOCATION_HEALTH_MALUS(), info.getChar(), GC.getTerrainInfo(pCityCenterPlot->getTerrainType()).getTextKeyWide()));
+				bLocationBreakdown = true;
+			}
+		}
+
+		if (!bLocationBreakdown)
+		{
+			int iCityHealthChangeFromCentralPlot = city.getCityHealthChangeFromCentralPlot();
+			szBuffer.append(gDLL->getText("TXT_KEY_YIELD_HEALTH_CITY_PLOT_CHANGE", info.getTextKeyWide(), iCityHealthChangeFromCentralPlot, info.getChar()));
+		}
 
 		szBuffer.append(SEPARATOR);
 		szBuffer.append(NEWLINE);
@@ -9252,6 +9298,22 @@ int CvGameTextMgr::setCityYieldModifierString(CvWStringBuffer& szBuffer, YieldTy
 		szBuffer.append(NEWLINE);
 		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_BUILDINGS", iBuildingMod, info.getChar()));
 		iBaseModifier += iBuildingMod;
+	}
+
+	int iPlayerMod = kOwner.getYieldRateModifier(eYieldType);
+	if (0 != iPlayerMod)
+	{
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_PLAYER", iPlayerMod, info.getChar()));
+		iBaseModifier += iPlayerMod;
+	}
+
+	int iTaxMod = kOwner.getTaxYieldRateModifier(eYieldType);
+	if (0 != iTaxMod)
+	{
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_TAX", iTaxMod, info.getChar()));
+		iBaseModifier += iTaxMod;
 	}
 
 	// Capital

--- a/Project Files/DLLSources/CvGameTextMgr.cpp
+++ b/Project Files/DLLSources/CvGameTextMgr.cpp
@@ -8833,7 +8833,10 @@ void CvGameTextMgr::setYieldHelp(CvWStringBuffer &szBuffer, CvCity& city, YieldT
 	// workers (carpenter, preacher, statesman) still need the % breakdown.
 	if (iModifiedProduction != 0)
 	{
-		int iModifier = setCityYieldModifierString(szBuffer, eYieldType, city);
+		setCityYieldModifierString(szBuffer, eYieldType, city);
+		// Use the same modifier the city applies to yields. The help string is
+		// only the breakdown; a reconstructed sum can drift from the real value.
+		int iModifier = city.getBaseYieldRateModifier(eYieldType);
 		if (iModifier != 100)
 		{
 			iModifiedProduction *= iModifier;
@@ -9300,22 +9303,6 @@ int CvGameTextMgr::setCityYieldModifierString(CvWStringBuffer& szBuffer, YieldTy
 		iBaseModifier += iBuildingMod;
 	}
 
-	int iPlayerMod = kOwner.getYieldRateModifier(eYieldType);
-	if (0 != iPlayerMod)
-	{
-		szBuffer.append(NEWLINE);
-		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_PLAYER", iPlayerMod, info.getChar()));
-		iBaseModifier += iPlayerMod;
-	}
-
-	int iTaxMod = kOwner.getTaxYieldRateModifier(eYieldType);
-	if (0 != iTaxMod)
-	{
-		szBuffer.append(NEWLINE);
-		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_TAX", iTaxMod, info.getChar()));
-		iBaseModifier += iTaxMod;
-	}
-
 	// Capital
 	if (kCity.isCapital())
 	{
@@ -9327,6 +9314,12 @@ int CvGameTextMgr::setCityYieldModifierString(CvWStringBuffer& szBuffer, YieldTy
 			iBaseModifier += iCapitalMod;
 		}
 	}
+
+	// Civics and founding fathers are already stored in the player yield/tax
+	// caches. List them by name here, then only add any leftover cache that
+	// those XML loops did not cover (do not add the caches themselves or they
+	// are counted twice and Total Production exceeds Final Production).
+	int iListedPlayerMod = 0;
 
 	// Civics
 	int iCivicMod = 0;
@@ -9342,6 +9335,7 @@ int CvGameTextMgr::setCityYieldModifierString(CvWStringBuffer& szBuffer, YieldTy
 		szBuffer.append(NEWLINE);
 		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_CIVICS", iCivicMod, info.getChar()));
 		iBaseModifier += iCivicMod;
+		iListedPlayerMod += iCivicMod;
 	}
 
 	// Founding Fathers
@@ -9360,10 +9354,20 @@ int CvGameTextMgr::setCityYieldModifierString(CvWStringBuffer& szBuffer, YieldTy
 			if (0 != iTraitMod)
 			{
 				iBaseModifier += iTraitMod;
+				iListedPlayerMod += iTraitMod;
 				szBuffer.append(NEWLINE);
 				szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_FATHER", iTraitMod, info.getChar(), kTraitInfo.getTextKeyWide()));
 			}
 		}
+	}
+
+	int iPlayerCacheMod = kOwner.getYieldRateModifier(eYieldType) + kOwner.getTaxYieldRateModifier(eYieldType);
+	int iUnlistedPlayerMod = iPlayerCacheMod - iListedPlayerMod;
+	if (0 != iUnlistedPlayerMod)
+	{
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HELP_YIELD_PLAYER", iUnlistedPlayerMod, info.getChar()));
+		iBaseModifier += iUnlistedPlayerMod;
 	}
 
 	// WTP, ray, trying to fix Rebel Rate Modifier on Happiness for Balancing - START


### PR DESCRIPTION
## Summary
City-screen title-bar stats that sit over the 3D city view (health, happiness, harbour, barracks, defense) were losing hover to terrain plot help. This PR moves those hoverable widgets off the map frame, keeps the remaining title-bar stats readable, and fills gaps in the yield/health tooltip breakdowns.

## City screen UI (`CvMainInterface.py`)
- The 3D city viewport steals mouse hover from `setLabel` widgets drawn over it. Hoverable title-bar stats now use `setText` + `Button_Stone_Style` (same pattern as Growing / population) and are placed left of the map or right of `iMapRight`.
- City scroll arrows sit next to the city name so they no longer collide with the left stats.
- Happiness stays after law/crime on the left; health, harbour, barracks, defense, and storage sit on the right.
- Culture header now shows surplus + stored/threshold + turns, e.g. `4♣ 58/200 (36 turns)`.
- `CityTopBackground` is hit-test solid so transparent title-bar art does not pass clicks through to the map.

## Yield / health tooltips (`CvGameTextMgr.cpp` + text XML)
- `setCityYieldModifierString` was only called when leftover plot `iBaseProduction != 0`. Indoor/building yields (hammers, bells, crosses, etc.) therefore skipped the percent breakdown, so Final Production could show 9 while the tooltip listed 7 produced. The modifier lines now appear whenever modified production is non-zero.
- Civilization `getYieldRateModifier` and tax `getTaxYieldRateModifier` are now listed in that breakdown.
- Health-by-location is no longer a single combined line. The tooltip lists each applied city-center bonus:
  - fresh water
  - coast
  - hills
  - bad terrain (with the actual terrain name)
- If none of those apply, the old `Health by city location = 0` line is kept.

## Test plan
- [x] Compiled FinalRelease DLL locally and verified the city screen in-game.
- [ ] Full-quit Colonization and reload so both Python and the DLL are picked up.
- [ ] Hover health / happiness / harbour / barracks / defense on the city title bar: breakdowns, not terrain help.
- [ ] Confirm city name, scroll arrows, Growing, left yields, and right storage/EXIT do not overlap at 1280 and 1920 widths.
- [ ] Hover hammers / bells / crosses on a city whose plot does not produce that yield: percent modifiers still appear and match Final Production.
- [ ] Hover health on cities with fresh water, coast, hills, and/or bad terrain: each applied bonus is listed separately.

## Notes
- DLL change: players need a rebuilt `CvGameCoreDLL.dll`. The compiled binary is gitignored and is not in this PR.
- Local compile helper `compile_finalrelease.bat` is not included.
- Happy to split the Python layout from the DLL tooltip work if you would rather review them separately.