### PR TITLE
Stop west-starting civs from auto-completing the Pacific passage quest

### DIFF
--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -3208,9 +3208,18 @@ def canTriggerPacificDone(argsList):
 	player = gc.getPlayer(kTriggeredData.ePlayer)
 	iAchieve = gc.getInfoTypeForString("ACHIEVE_PACIFIC")
 	#CyInterface().addImmediateMessage("iAchieve "+str(iAchieve), "")
-	if player.isAchieveGained(iAchieve):
-		return True
-	return False
+	if not player.isAchieveGained(iAchieve):
+		return False
+
+	# Same start-side rule as canTriggerPacific: west-starting civs must not complete this.
+	city = player.getCity(kTriggeredData.iCityId)
+	if city is None or city.isNone():
+		(city, iter) = player.firstCity(True)
+	if city is None or city.isNone():
+		return False
+	if city.getX() <= CyMap().getGridWidth() / 2:
+		return False
+	return True
 
 ######## Atlantic Quest ###########
 
@@ -3251,10 +3260,18 @@ def canTriggerAtlanticDone(argsList):
 
 	iAchieve = gc.getInfoTypeForString("ACHIEVE_ATLANTIC")
 
-	if player.isAchieveGained(iAchieve):
-		return True
+	if not player.isAchieveGained(iAchieve):
+		return False
 
-	return False
+	# Same start-side rule as canTriggerAtlantic: east-starting civs must not complete this.
+	city = player.getCity(kTriggeredData.iCityId)
+	if city is None or city.isNone():
+		(city, iter) = player.firstCity(True)
+	if city is None or city.isNone():
+		return False
+	if city.getX() > CyMap().getGridWidth() / 2:
+		return False
+	return True
 
 ######## VOLCANO ###########
 

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -21235,38 +21235,35 @@ void CvPlayer::doAchievements(bool afterMove)
 							}
 						}
 					}
-					if (GC.getAchieveInfo((AchieveTypes)iI).isDiscoverEast())
+					if (GC.getAchieveInfo((AchieveTypes)iI).isDiscoverEast() || GC.getAchieveInfo((AchieveTypes)iI).isDiscoverWest())
 					{
-						for (iJ = 0; iJ < GC.getMap().numPlotsINLINE(); iJ++)
+						// Passage quests are "cross the continent". A civ whose colony is
+						// already on that ocean must not get the achievement from start vision.
+						const CvCity* pHomeCity = getCapitalCity();
+						if (pHomeCity == NULL)
 						{
-							pPlot = GC.getMap().plotByIndexINLINE(iJ);
-							if (pPlot->isRevealed(getTeam(), false))
-							{
-								// WTP, ray, fixing issue for Europe East / West Achievement
-								// we only trigger if there is no Improvement on it to prevent Reveal Goody Bug
-								// I have no idea why I cannot use EUROPE_EAST
-								if (pPlot->isEurope() && pPlot->getEurope() == EUROPE_EAST && pPlot->getImprovementType() == NO_IMPROVEMENT)
-								{
-									bGained = true;
-									iJ = GC.getMap().numPlotsINLINE();
-								}
-							}
+							int iHomeLoop = 0;
+							pHomeCity = firstCity(&iHomeLoop);
 						}
-					}
-					if (GC.getAchieveInfo((AchieveTypes)iI).isDiscoverWest())
-					{
-						for (iJ = 0; iJ < GC.getMap().numPlotsINLINE(); iJ++)
+						const bool bHomeOnEastHalf = (pHomeCity != NULL && pHomeCity->getX_INLINE() > GC.getMap().getGridWidthINLINE() / 2);
+						const bool bMayDiscoverEast = (pHomeCity != NULL && !bHomeOnEastHalf);
+						const bool bMayDiscoverWest = bHomeOnEastHalf;
+
+						if ((GC.getAchieveInfo((AchieveTypes)iI).isDiscoverEast() && bMayDiscoverEast) ||
+							(GC.getAchieveInfo((AchieveTypes)iI).isDiscoverWest() && bMayDiscoverWest))
 						{
-							pPlot = GC.getMap().plotByIndexINLINE(iJ);
-							if (pPlot->isRevealed(getTeam(), false))
+							const EuropeTypes eWantedEurope = GC.getAchieveInfo((AchieveTypes)iI).isDiscoverWest() ? EUROPE_WEST : EUROPE_EAST;
+							for (iJ = 0; iJ < GC.getMap().numPlotsINLINE(); iJ++)
 							{
-								// WTP, ray, fixing issue for Europe East / West Achievement
-								// we only trigger if there is no Improvement on it to prevent Reveal Goody Bug
-								// I have no idea why I cannot use EUROPE_WEST
-								if (pPlot->isEurope() && pPlot->getEurope() == EUROPE_WEST && pPlot->getImprovementType() == NO_IMPROVEMENT)
+								pPlot = GC.getMap().plotByIndexINLINE(iJ);
+								if (pPlot->isRevealed(getTeam(), false))
 								{
-									bGained = true;
-									iJ = GC.getMap().numPlotsINLINE();
+									// Skip goody-revealed tiles (improvement present) to avoid the reveal-goody bug.
+									if (pPlot->isEurope() && pPlot->getEurope() == eWantedEurope && pPlot->getImprovementType() == NO_IMPROVEMENT)
+									{
+										bGained = true;
+										iJ = GC.getMap().numPlotsINLINE();
+									}
 								}
 							}
 						}


### PR DESCRIPTION
## Summary
On some maps a colonial civ already starts on the west coast. Their first ships reveal `EUROPE_WEST` tiles immediately, so they gain `ACHIEVE_PACIFIC` and can collect the western-passage quest reward (gold and founding-father points) without crossing the continent.

The same hole exists the other way for the Atlantic / eastern-passage quest.

## Change
- `CvPlayer::doAchievements`: grant Discover West only if the capital / first city is on the **eastern** half of the map. Grant Discover East only from the **western** half. No city means no achievement.
- `canTriggerPacificDone` / `canTriggerAtlanticDone`: the same start-side check, so a leftover achievement cannot complete the wrong quest.

Existing start-side filters on `canTriggerPacific` / `canTriggerAtlantic` are unchanged.

## Test plan
- [x] Compiled FinalRelease locally.
- [ ] New map, east-coast start: Pacific quest still completes only after revealing `EUROPE_WEST`.
- [ ] New map, west-coast start: no instant Pacific achievement or quest reward.
- [ ] New map, west-coast start: Atlantic quest still completes only after revealing `EUROPE_EAST`.
- [ ] New map, east-coast start: no instant Atlantic achievement.

## Notes
- DLL change: players need a rebuilt `CvGameCoreDLL.dll`. The compiled binary is gitignored and is not in this PR.
- Python change applies on game restart.