### PR TITLE
Keep World Builder bonus placements when playing a scenario

### DIFF
--- a/Assets/Python/EntryPoints/CvWBInterface.py
+++ b/Assets/Python/EntryPoints/CvWBInterface.py
@@ -118,20 +118,31 @@ def getPlayerData():
 	"after reading a save file, return player data as a tuple, terminated by -1"
 	t=()
 	for i in range(gc.getMAX_CIV_PLAYERS()):
-		leaderType = CvUtil.findInfoTypeNum(WBDesc.playersDesc[i].leaderType)
-		civType = CvUtil.findInfoTypeNum(WBDesc.playersDesc[i].civType)
-		handicapType = CvUtil.findInfoTypeNum(WBDesc.playersDesc[i].handicap)
-		color = CvUtil.findInfoTypeNum(WBDesc.playersDesc[i].color)
-		artStyle = gc.getInfoTypeForString(WBDesc.playersDesc[i].artStyle)
+		pWBPlayer = WBDesc.playersDesc[i]
+		# Church / animals: the DLL creates these. Passing them in as scenario
+		# civs crashes initEuropeSettler because they have no cities.
+		if pWBPlayer.civType == "NONE" or CvWBDesc.isDllCreatedCiv(pWBPlayer.civType):
+			civType = -1
+			leaderType = -1
+			color = -1
+			artStyle = -1
+			isPlayableCiv = 0
+		else:
+			leaderType = CvUtil.findInfoTypeNum(pWBPlayer.leaderType)
+			civType = CvUtil.findInfoTypeNum(pWBPlayer.civType)
+			color = CvUtil.findInfoTypeNum(pWBPlayer.color)
+			artStyle = gc.getInfoTypeForString(pWBPlayer.artStyle)
+			isPlayableCiv = pWBPlayer.isPlayableCiv
+		handicapType = CvUtil.findInfoTypeNum(pWBPlayer.handicap)
 
 		t=t+(civType,)
-		t=t+(WBDesc.playersDesc[i].isPlayableCiv,)
+		t=t+(isPlayableCiv,)
 		t=t+(leaderType,)
 		t=t+(handicapType,)
-		t=t+(WBDesc.playersDesc[i].team,)
+		t=t+(pWBPlayer.team,)
 		t=t+(color,)
 		t=t+(artStyle,)
-		t=t+(WBDesc.playersDesc[i].isMinorNationCiv,)
+		t=t+(pWBPlayer.isMinorNationCiv,)
 
 	return t
 

--- a/Assets/Python/pyWB/CvWBDesc.py
+++ b/Assets/Python/pyWB/CvWBDesc.py
@@ -23,6 +23,12 @@ def getPlayer(idx):
 		return gc.getPlayer(idx)
 	return None
 
+def isWbFlagTrue(value):
+	# WB files write False/True; applyMap used to compare only to "false".
+	if value is None:
+		return False
+	return str(value).strip().lower() in ("true", "1", "yes")
+
 #############
 class CvWBParser:
 	"parser functions for WB desc"
@@ -1191,8 +1197,9 @@ class CvMapDesc:
 		f.write("\tsealevel=%s\n" %(gc.getSeaLevelInfo(map.getSeaLevel()).getType(),))
 		f.write("\tnum plots written=%d\n" %(iNumPlots,))
 		f.write("\tnum signs written=%d\n" %(iNumSigns,))
-		f.write("\tRandomize Features=False\n") #WTP, ray, Randomize Features Map Option
-		f.write("\tRandomize Resources=False\n")
+		f.write("\tRandomize Features=false\n") #WTP, ray, Randomize Features Map Option
+		f.write("\tRandomize Resources=false\n")
+		f.write("\tRandomize Goodies=false\n")
 		f.write("\tCity Catchment Radius=%d\n" %(map.getCityCatchmentRadius(),))
 		f.write("EndMap\n")
 
@@ -1435,17 +1442,17 @@ class CvWBDesc:
 		# Before touching bonuses and features, we first need to ensure that the plots have coast, lake etc set correctly
 		CyMap().updateWaterPlotTerrainTypes()
 
-		if (self.mapDesc.bRandomizeFeatures != "false"): #WTP, ray, Randomize Features Map Option
+		if isWbFlagTrue(self.mapDesc.bRandomizeFeatures):
 			CyMapGenerator().eraseFeaturesOnLand()
 			CyMapGenerator().addFeaturesOnLand()
 			
-		if (self.mapDesc.bRandomizeResources != "false"):
+		if isWbFlagTrue(self.mapDesc.bRandomizeResources):
 			for iPlotLoop in range(CyMap().numPlots()):
 				pPlot = CyMap().plotByIndex(iPlotLoop)
 				pPlot.setBonusType(BonusTypes.NO_BONUS)
 			CyMapGenerator().addBonuses()
 			
-		if (self.mapDesc.bRandomizeGoodies != "false"):
+		if isWbFlagTrue(self.mapDesc.bRandomizeGoodies):
 			CyMapGenerator().eraseGoodies()
 			CyMapGenerator().addGoodies()
 

--- a/Assets/Python/pyWB/CvWBDesc.py
+++ b/Assets/Python/pyWB/CvWBDesc.py
@@ -296,27 +296,27 @@ class CvTeamDesc:
 		f.write("\tTeamID=%d\n" %(idx))
 		# write met other teams
 		for i in range(gc.getMAX_CIV_TEAMS()):
-			if (gc.getTeam(idx).isHasMet(i)):
+			if (i != idx and gc.getTeam(idx).isHasMet(i)):
 				f.write("\tContactWithTeam=%d\n" %(i))
 
 		# write warring teams
 		for i in range(gc.getMAX_CIV_TEAMS()):
-			if (gc.getTeam(idx).isAtWar(i)):
+			if (i != idx and gc.getTeam(idx).isAtWar(i)):
 				f.write("\tAtWar=%d\n" %(i))
 
 		# write permanent war/peace teams
 		for i in range(gc.getMAX_CIV_TEAMS()):
-			if (gc.getTeam(idx).isPermanentWarPeace(i)):
+			if (i != idx and gc.getTeam(idx).isPermanentWarPeace(i)):
 				f.write("\tPermanentWarPeace=%d\n" %(i))
 
 		# write open borders other teams
 		for i in range(gc.getMAX_CIV_TEAMS()):
-			if (gc.getTeam(idx).isOpenBorders(i)):
+			if (i != idx and gc.getTeam(idx).isOpenBorders(i)):
 				f.write("\tOpenBordersWithTeam=%d\n" %(i))
 
 		# write defensive pact other teams
 		for i in range(gc.getMAX_CIV_TEAMS()):
-			if (gc.getTeam(idx).isDefensivePact(i)):
+			if (i != idx and gc.getTeam(idx).isDefensivePact(i)):
 				f.write("\tDefensivePactWithTeam=%d\n" %(i))
 
 		f.write("\tRevealMap=%d\n" %(0))
@@ -1492,47 +1492,90 @@ class CvWBDesc:
 	def identifyValidPlayersAndTeams(self):
 		self.validPlayers = [0] * gc.getMAX_CIV_PLAYERS()
 		self.validTeams   = [0] * gc.getMAX_CIV_TEAMS()
-		
-		for iPlayerLoop in range(gc.getMAX_CIV_PLAYERS()):
+
+		if self.playersDesc is None:
+			return
+
+		iMaxPlayers = min(gc.getMAX_CIV_PLAYERS(), len(self.playersDesc))
+		iMaxTeams = len(self.validTeams)
+		for iPlayerLoop in range(iMaxPlayers):
 			if (self.playersDesc[iPlayerLoop]):
 				pWBPlayer = self.playersDesc[iPlayerLoop]
-				if (pWBPlayer.civType != 'NONE' and self.validTeams[pWBPlayer.team] != -1):
+				iTeam = pWBPlayer.team
+				if (pWBPlayer.civType != 'NONE' and iTeam >= 0 and iTeam < iMaxTeams):
 					self.validPlayers[iPlayerLoop] = 1
-					self.validTeams[pWBPlayer.team] = 1
+					self.validTeams[iTeam] = 1
+
+	def _isUsableTeam(self, iTeam, iSkipTeam=-1):
+		if iTeam is None:
+			return False
+		try:
+			iTeam = int(iTeam)
+		except:
+			return False
+		if iTeam < 0:
+			return False
+		if iSkipTeam != -1 and iTeam == iSkipTeam:
+			return False
+		if iTeam >= gc.getMAX_CIV_TEAMS():
+			return False
+		if self.validTeams is None or iTeam >= len(self.validTeams):
+			return False
+		if self.teamsDesc is None or iTeam >= len(self.teamsDesc):
+			return False
+		if not self.validTeams[iTeam]:
+			return False
+		if not self.teamsDesc[iTeam]:
+			return False
+		return True
 
 	def applyInitialTeams1(self):
 		# Team stuff
-		if (len(self.teamsDesc)) :
-			for iTeamLoop in range(gc.getMAX_CIV_TEAMS()):
+		if (not self.teamsDesc) :
+			return
 
-				if (self.validTeams[iTeamLoop] and self.teamsDesc[iTeamLoop]):
+		iLimit = gc.getMAX_CIV_TEAMS()
+		if iLimit > len(self.teamsDesc):
+			iLimit = len(self.teamsDesc)
+		if self.validTeams is not None and iLimit > len(self.validTeams):
+			iLimit = len(self.validTeams)
 
-					pTeam = gc.getTeam(iTeamLoop)
-					pWBTeam = self.teamsDesc[iTeamLoop]
-					# Contact with Other Teams
-					for meetTeam in self.teamsDesc[iTeamLoop].bContactWithTeamList:
-						if (self.validTeams[meetTeam]):
-							gc.getTeam(iTeamLoop).meet(meetTeam, False)
+		for iTeamLoop in range(iLimit):
 
-					# Wars
-					for warTeam in self.teamsDesc[iTeamLoop].bWarWithTeamList:
-						if (self.validTeams[warTeam]):
-							gc.getTeam(iTeamLoop).declareWar(warTeam, False, WarPlanTypes.NO_WARPLAN)
+			if (self._isUsableTeam(iTeamLoop)):
 
-					# Permanent War/Peace
-					for permanentWarPeaceTeam in self.teamsDesc[iTeamLoop].bPermanentWarPeaceList:
-						if (self.validTeams[permanentWarPeaceTeam]):
-							gc.getTeam(iTeamLoop).setPermanentWarPeace(permanentWarPeaceTeam, True)
+				pTeam = gc.getTeam(iTeamLoop)
+				pWBTeam = self.teamsDesc[iTeamLoop]
+				# Contact with Other Teams
+				for meetTeam in pWBTeam.bContactWithTeamList:
+					if (self._isUsableTeam(meetTeam, iTeamLoop)):
+						pTeam.meet(meetTeam, False)
 
-					# Open Borders
-					for openBordersTeam in self.teamsDesc[iTeamLoop].bOpenBordersWithTeamList:
-						if (self.validTeams[openBordersTeam]):
-							gc.getTeam(iTeamLoop).signOpenBorders(openBordersTeam)
+				# Wars
+				for warTeam in pWBTeam.bWarWithTeamList:
+					if (self._isUsableTeam(warTeam, iTeamLoop)):
+						pOtherTeam = gc.getTeam(warTeam)
+						# declareWar() vs a parent starts a revolution during scenario load
+						if pTeam.isParentOf(warTeam) or pOtherTeam.isParentOf(iTeamLoop):
+							continue
+						pTeam.declareWar(warTeam, False, WarPlanTypes.NO_WARPLAN)
 
-					# Defensive Pacts
-					for defensivePactTeam in self.teamsDesc[iTeamLoop].bDefensivePactWithTeamList:
-						if (self.validTeams[defensivePactTeam]):
-							gc.getTeam(iTeamLoop).signDefensivePact(defensivePactTeam)
+				# Permanent War/Peace
+				for permanentWarPeaceTeam in pWBTeam.bPermanentWarPeaceList:
+					if (self._isUsableTeam(permanentWarPeaceTeam, iTeamLoop)):
+						pTeam.setPermanentWarPeace(permanentWarPeaceTeam, True)
+
+				# Open Borders
+				for openBordersTeam in pWBTeam.bOpenBordersWithTeamList:
+					if (self._isUsableTeam(openBordersTeam, iTeamLoop)):
+						if pTeam.getLeaderID() >= 0 and gc.getTeam(openBordersTeam).getLeaderID() >= 0:
+							pTeam.signOpenBorders(openBordersTeam)
+
+				# Defensive Pacts
+				for defensivePactTeam in pWBTeam.bDefensivePactWithTeamList:
+					if (self._isUsableTeam(defensivePactTeam, iTeamLoop)):
+						if pTeam.getLeaderID() >= 0 and gc.getTeam(defensivePactTeam).getLeaderID() >= 0:
+							pTeam.signDefensivePact(defensivePactTeam)
 
 	def applyInitialPlayers(self):
 		# Player stuff
@@ -1571,7 +1614,8 @@ class CvWBDesc:
 					for iAttitudeLoop in range(len(pWBPlayer.aaiAttitudeExtras)):
 						iPlayer = pWBPlayer.aaiAttitudeExtras[iAttitudeLoop][0]
 						iExtra = pWBPlayer.aaiAttitudeExtras[iAttitudeLoop][1]
-						pPlayer.AI_setAttitudeExtra(iPlayer,iExtra)
+						if iPlayer >= 0 and iPlayer < gc.getMAX_CIV_PLAYERS() and self.validPlayers[iPlayer]:
+							pPlayer.AI_setAttitudeExtra(iPlayer,iExtra)
 
 					# City List
 					for iCityListLoop in range(len(pWBPlayer.aszCityList)):
@@ -1584,10 +1628,16 @@ class CvWBDesc:
 
 	def applyInitialTeams2(self):
 		# Team stuff
-		if (len(self.teamsDesc)) :
-			for iTeamLoop in range(gc.getMAX_CIV_TEAMS()):
+		if (not self.teamsDesc) :
+			return
+		iLimit = gc.getMAX_CIV_TEAMS()
+		if iLimit > len(self.teamsDesc):
+			iLimit = len(self.teamsDesc)
+		if self.validTeams is not None and iLimit > len(self.validTeams):
+			iLimit = len(self.validTeams)
+		for iTeamLoop in range(iLimit):
 
-				if (self.validTeams[iTeamLoop] and self.teamsDesc[iTeamLoop]):
+			if (self._isUsableTeam(iTeamLoop)):
 
 					pTeam = gc.getTeam(iTeamLoop)
 					pWBTeam = self.teamsDesc[iTeamLoop]
@@ -1602,13 +1652,19 @@ class CvWBDesc:
 
 	def applyInitialPlots(self):
 		# Per plot stuff
-		for iPlotLoop in range(self.mapDesc.numPlotsWritten):
+		iPlotLimit = self.mapDesc.numPlotsWritten
+		if self.plotDesc is not None and iPlotLimit > len(self.plotDesc):
+			iPlotLimit = len(self.plotDesc)
+		for iPlotLoop in range(iPlotLimit):
 
 			pWBPlot = self.plotDesc[iPlotLoop]
 
 			# Reveal Fog of War for teams
-			for iTeamLoop in range(gc.getMAX_CIV_TEAMS()):
-				if (self.validTeams[iTeamLoop]):
+			iTeamLimit = gc.getMAX_CIV_TEAMS()
+			if pWBPlot.abTeamPlotRevealed is not None and iTeamLimit > len(pWBPlot.abTeamPlotRevealed):
+				iTeamLimit = len(pWBPlot.abTeamPlotRevealed)
+			for iTeamLoop in range(iTeamLimit):
+				if (self._isUsableTeam(iTeamLoop)):
 					pTeam = gc.getTeam(iTeamLoop)
 					if (pWBPlot.abTeamPlotRevealed[iTeamLoop] == 1):
 						pPlot = CyMap().plot(pWBPlot.iX, pWBPlot.iY)

--- a/Assets/Python/pyWB/CvWBDesc.py
+++ b/Assets/Python/pyWB/CvWBDesc.py
@@ -29,6 +29,15 @@ def isWbFlagTrue(value):
 		return False
 	return str(value).strip().lower() in ("true", "1", "yes")
 
+def isDllCreatedCiv(civType):
+	# Church and wild animals are spawned by the DLL in setInitialItems.
+	# Official maps leave those slots as NONE. A live-game WB save writes them,
+	# and Play Scenario then inits unplayable civs, which later hit
+	# initEuropeSettler / getCivilizationInfo(-1).
+	if civType is None:
+		return False
+	return str(civType) in ("CIVILIZATION_CHURCH", "CIVILIZATION_BARBARIAN")
+
 #############
 class CvWBParser:
 	"parser functions for WB desc"
@@ -403,14 +412,20 @@ class CvPlayerDesc:
 		f.write("\tTeam=%d\n" %(int(gc.getPlayer(idx).getTeam())))
 
 		# write leader and Civ Description info
-		if (gc.getPlayer(idx).getLeaderType() == LeaderHeadTypes.NO_LEADER):
+		eCiv = gc.getPlayer(idx).getCivilizationType()
+		bDllCreated = False
+		if eCiv != CivilizationTypes.NO_CIVILIZATION:
+			bDllCreated = isDllCreatedCiv(gc.getCivilizationInfo(eCiv).getType())
+
+		if (gc.getPlayer(idx).getLeaderType() == LeaderHeadTypes.NO_LEADER) or bDllCreated:
 			f.write("\tLeaderType=NONE\n")
 
 		else:
 			f.write("\tLeaderType=%s\n" %(gc.getLeaderHeadInfo(gc.getPlayer(idx).getLeaderType()).getType()))
 
 		# write civ, color, artStyle, isPlayableCiv, isMinorNation, StartingGold
-		if (gc.getPlayer(idx).getCivilizationType() == CivilizationTypes.NO_CIVILIZATION):
+		# Church / animals: write NONE so the DLL can create them on scenario start
+		if (eCiv == CivilizationTypes.NO_CIVILIZATION) or bDllCreated:
 			f.write("\tCivType=NONE\n")
 			f.write("\tColor=NONE\n")
 			f.write("\tArtStyle=NONE\n")
@@ -432,7 +447,7 @@ class CvPlayerDesc:
 
 			f.write("\tStartingEra=%s\n" %(gc.getEraInfo(gc.getPlayer(idx).getCurrentEra()).getType()))
 
-			f.write("\tRandomStartLocation=False\n")
+			f.write("\tRandomStartLocation=false\n")
 
 			# write Civics
 			for iCivicOptionLoop in range(gc.getNumCivicOptionInfos()):
@@ -1468,7 +1483,7 @@ class CvWBDesc:
 			pWBPlayer = self.playersDesc[iPlayerLoop]
 
 			# Random Start Location
-			if (pPlayer.getLeaderType() != -1 and pWBPlayer.bRandomStartLocation != "false"):
+			if (pPlayer.getLeaderType() != -1 and isWbFlagTrue(pWBPlayer.bRandomStartLocation)):
 				pPlayer.setStartingPlot(pPlayer.findStartingPlot(True), True)
 			else:
 
@@ -1502,7 +1517,7 @@ class CvWBDesc:
 			if (self.playersDesc[iPlayerLoop]):
 				pWBPlayer = self.playersDesc[iPlayerLoop]
 				iTeam = pWBPlayer.team
-				if (pWBPlayer.civType != 'NONE' and iTeam >= 0 and iTeam < iMaxTeams):
+				if (pWBPlayer.civType != 'NONE' and not isDllCreatedCiv(pWBPlayer.civType) and iTeam >= 0 and iTeam < iMaxTeams):
 					self.validPlayers[iPlayerLoop] = 1
 					self.validTeams[iTeam] = 1
 
@@ -1600,7 +1615,7 @@ class CvWBDesc:
 						pPlayer.setCurrentEra(iStartingEra)
 
 					# Random Start Location
-					if (pWBPlayer.bRandomStartLocation != "false"):
+					if isWbFlagTrue(pWBPlayer.bRandomStartLocation):
 						pPlayer.setStartingPlot(pPlayer.findStartingPlot(True), True)
 						print("Setting player %d starting location to (%d,%d)", pPlayer.getID(), pPlayer.getStartingPlot().getX(), pPlayer.getStartingPlot().getY())
 


### PR DESCRIPTION
## Summary

World Builder maps already store each plot bonus (`BonusType=BONUS_HEMP` etc.) and write `Randomize Resources=False` so Play Scenario is supposed to keep those placements.

`applyMap()` compared the flag only to lowercase `false`. The saved value is `False`, so the check treated every WB map as randomize, wiped all bonuses, and ran `addBonuses()` again. Features had the same case bug.

## Change

- Treat `Randomize Resources`, `Randomize Features`, and `Randomize Goodies` case-insensitively (`true` / `1` / `yes` randomize; anything else keeps the WB placements).
- Write the three flags as lowercase `false` on save so they match the stored default.
- Also write `Randomize Goodies=false` (it was read but never saved).

Python only. No DLL rebuild. Existing WB maps with `Randomize Resources=False` keep their bonuses after a game restart.

## Test plan

- Save a World Builder map with a few hand-placed bonuses.
- Play Scenario from that map: those bonuses stay on the same tiles.
- Optional: set `Randomize Resources=true` in the `BeginMap` block and confirm bonuses are regenerated.

## Notes

- No compiled `CvGameCoreDLL.dll`.
- `Randomize Resources=true` still forces a fresh scatter if a scenario author wants that.