### PR TITLE
Show trade-quest standings and stolen crime gold

### DIFF
--- a/Assets/Python/CvEventManager.py
+++ b/Assets/Python/CvEventManager.py
@@ -426,6 +426,7 @@ class CvEventManager:
 		'Called at the beginning of a players turn'
 		iGameTurn, iPlayer = argsList
 		CvRandomEventInterface.checkEuropeanBorderDisputeKingWarDemand(iPlayer)
+		CvRandomEventInterface.checkTradeQuestLeadershipChanges(iPlayer)
 
 	def onEndPlayerTurn(self, argsList):
 		'Called at the end of a players turn'

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -12397,17 +12397,15 @@ def CanDoEuropeTrade(argsList, iYieldID, iQuantity):
 		return False
 	return True
 
-def _appendTradeQuestStandings(szHelp, iYield, eLocation, eActivePlayer):
-	# Live race standings for first-to-ship-X quests. Sold totals for cargo exports;
-	# bought totals for trade/luxury goods imported from that market.
+def _getTradeQuestStandings(iYield, eLocation):
+	standings = []
 	if iYield < 0:
-		return szHelp
+		return standings
 
 	iTradeGoods = gc.getInfoTypeForString("YIELD_TRADE_GOODS")
 	iLuxuryGoods = gc.getInfoTypeForString("YIELD_LUXURY_GOODS")
 	bBuy = (iYield == iTradeGoods or iYield == iLuxuryGoods)
 
-	standings = []
 	for iPlayer in range(gc.getMAX_PLAYERS()):
 		loopPlayer = gc.getPlayer(iPlayer)
 		if loopPlayer is None or loopPlayer.isNone() or not loopPlayer.isAlive():
@@ -12425,10 +12423,16 @@ def _appendTradeQuestStandings(szHelp, iYield, eLocation, eActivePlayer):
 			iAmount = loopPlayer.getYieldSoldTotal(eLocation, iYield)
 		standings.append((iAmount, iPlayer, loopPlayer))
 
+	standings.sort(key=lambda item: (-item[0], item[1]))
+	return standings
+
+def _appendTradeQuestStandings(szHelp, iYield, eLocation, eActivePlayer):
+	# Live race standings for first-to-ship-X quests. Sold totals for cargo exports;
+	# bought totals for trade/luxury goods imported from that market.
+	standings = _getTradeQuestStandings(iYield, eLocation)
 	if len(standings) == 0:
 		return szHelp
 
-	standings.sort(key=lambda item: (-item[0], item[1]))
 	iLeadAmount = standings[0][0]
 
 	szHelp += localText.getText("TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_HEADER", ())
@@ -12444,6 +12448,193 @@ def _appendTradeQuestStandings(szHelp, iYield, eLocation, eActivePlayer):
 		else:
 			szHelp += localText.getText("TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_LINE", (loopPlayer.getCivilizationShortDescription(0), iAmount))
 	return szHelp
+
+def _getTradeQuestLeader(iYield, eLocation):
+	standings = _getTradeQuestStandings(iYield, eLocation)
+	if len(standings) == 0:
+		return -1, 0, None
+	iAmount, iPlayer, loopPlayer = standings[0]
+	if iAmount <= 0:
+		return -1, 0, None
+	return iPlayer, iAmount, loopPlayer
+
+TRADE_QUEST_LEADER_PREFIX = "[[TQLEAD:"
+TRADE_QUEST_LEADER_SUFFIX = "]]"
+_TRADE_QUEST_START_CACHE = None
+
+def _getTradeQuestStartInfos():
+	global _TRADE_QUEST_START_CACHE
+	if _TRADE_QUEST_START_CACHE is not None:
+		return _TRADE_QUEST_START_CACHE
+
+	cache = []
+	for iEvent in range(gc.getNumEventInfos()):
+		event = gc.getEventInfo(iEvent)
+		if event is None:
+			continue
+		if not event.isQuest():
+			continue
+		szType = event.getType()
+		if szType is None:
+			continue
+		if szType.find("_TRADE_QUEST_") == -1:
+			continue
+		if len(szType) < 6 or szType[-6:] != "_START":
+			continue
+
+		if szType.find("EVENT_EUROPE_TRADE_QUEST_") == 0:
+			eLocation = TradeLocationTypes.TRADE_LOCATION_EUROPE
+			szLocationKey = "TXT_KEY_EVENT_TRADE_QUEST_LOCATION_EUROPE"
+		elif szType.find("EVENT_AFRICA_TRADE_QUEST_") == 0:
+			eLocation = TradeLocationTypes.TRADE_LOCATION_AFRICA
+			szLocationKey = "TXT_KEY_EVENT_TRADE_QUEST_LOCATION_AFRICA"
+		elif szType.find("EVENT_PORTROYAL_TRADE_QUEST_") == 0:
+			eLocation = TradeLocationTypes.TRADE_LOCATION_PORT_ROYAL
+			szLocationKey = "TXT_KEY_EVENT_TRADE_QUEST_LOCATION_PORT_ROYAL"
+		else:
+			continue
+
+		iYield = event.getGenericParameter(2)
+		if iYield < 0:
+			continue
+		cache.append((iEvent, szType, eLocation, iYield, szLocationKey))
+
+	_TRADE_QUEST_START_CACHE = cache
+	return cache
+
+def _readTradeQuestLeaderStore(player):
+	leaders = {}
+	szData = player.getScriptData()
+	if szData is None:
+		return leaders
+	iStart = szData.find(TRADE_QUEST_LEADER_PREFIX)
+	if iStart == -1:
+		return leaders
+	iStart = iStart + len(TRADE_QUEST_LEADER_PREFIX)
+	iEnd = szData.find(TRADE_QUEST_LEADER_SUFFIX, iStart)
+	if iEnd == -1:
+		return leaders
+	szBody = szData[iStart:iEnd]
+	if szBody == "":
+		return leaders
+	aParts = szBody.split(";")
+	for szPart in aParts:
+		iEq = szPart.find("=")
+		if iEq < 1:
+			continue
+		szKey = szPart[:iEq]
+		try:
+			leaders[szKey] = int(szPart[iEq + 1:])
+		except:
+			continue
+	return leaders
+
+def _writeTradeQuestLeaderStore(player, leaders):
+	aParts = []
+	for szKey in leaders.keys():
+		aParts.append("%s=%d" % (szKey, leaders[szKey]))
+	szNew = TRADE_QUEST_LEADER_PREFIX + ";".join(aParts) + TRADE_QUEST_LEADER_SUFFIX
+
+	szData = player.getScriptData()
+	if szData is None:
+		szData = ""
+	iStart = szData.find(TRADE_QUEST_LEADER_PREFIX)
+	if iStart == -1:
+		player.setScriptData(szData + szNew)
+		return
+	iEnd = szData.find(TRADE_QUEST_LEADER_SUFFIX, iStart)
+	if iEnd == -1:
+		player.setScriptData(szData + szNew)
+		return
+	iEnd = iEnd + len(TRADE_QUEST_LEADER_SUFFIX)
+	player.setScriptData(szData[:iStart] + szNew + szData[iEnd:])
+
+def checkTradeQuestLeadershipChanges(iPlayer):
+	# Event-log ping when someone takes the lead on a first-to-ship quest the human already has.
+	player = gc.getPlayer(iPlayer)
+	if player is None or player.isNone():
+		return
+	if not player.isHuman():
+		return
+	if not player.isAlive():
+		return
+	if not player.isPlayable():
+		return
+	if player.isNative() or player.isEurope():
+		return
+
+	leaders = _readTradeQuestLeaderStore(player)
+	bDirty = False
+	aActive = {}
+
+	for iEvent, szType, eLocation, iYield, szLocationKey in _getTradeQuestStartInfos():
+		kData = player.getEventOccured(iEvent)
+		if kData is None:
+			continue
+		aActive[szType] = 1
+
+		iLeader, iAmount, leaderPlayer = _getTradeQuestLeader(iYield, eLocation)
+
+		if not leaders.has_key(szType):
+			leaders[szType] = iLeader
+			bDirty = True
+			continue
+
+		iPrevious = leaders[szType]
+		if iPrevious == iLeader:
+			continue
+
+		leaders[szType] = iLeader
+		bDirty = True
+
+		if iLeader < 0 or leaderPlayer is None:
+			continue
+
+		szLocation = localText.getText(szLocationKey, ())
+		iYieldChar = gc.getYieldInfo(iYield).getChar()
+		szButton = gc.getYieldInfo(iYield).getButton()
+
+		if iLeader == iPlayer:
+			szText = localText.getText(
+				"TXT_KEY_EVENT_TRADE_QUEST_LEADER_YOU",
+				(iYieldChar, szLocation, iAmount)
+			)
+			iColor = gc.getInfoTypeForString("COLOR_GREEN")
+		else:
+			szText = localText.getText(
+				"TXT_KEY_EVENT_TRADE_QUEST_LEADER_OTHER",
+				(iYieldChar, szLocation, leaderPlayer.getCivilizationShortDescription(0), iAmount)
+			)
+			if iPrevious == iPlayer:
+				iColor = gc.getInfoTypeForString("COLOR_RED")
+			else:
+				iColor = gc.getInfoTypeForString("COLOR_YELLOW")
+
+		CyInterface().addMessage(
+			iPlayer,
+			True,
+			gc.getEVENT_MESSAGE_TIME(),
+			szText,
+			"",
+			InterfaceMessageTypes.MESSAGE_TYPE_INFO,
+			szButton,
+			iColor,
+			-1,
+			-1,
+			True,
+			True
+		)
+
+	aToDelete = []
+	for szKey in leaders.keys():
+		if not aActive.has_key(szKey):
+			aToDelete.append(szKey)
+	for szKey in aToDelete:
+		del leaders[szKey]
+		bDirty = True
+
+	if bDirty:
+		_writeTradeQuestLeaderStore(player, leaders)
 
 # This is the Function for the Event Target Yield and Target Amount
 # This Function is only used for the "Quest Start"

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -15237,7 +15237,7 @@ def getHelpQuestStartAfricaTradeYieldAndAmount(argsList):
 	if quantity > 0 :
 		if iYield != gc.getInfoTypeForString("YIELD_TRADE_GOODS") and iYield != gc.getInfoTypeForString("YIELD_LUXURY_GOODS"):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_AFRICA_TRADE_YIELD_AND_TARGET_AMOUNT_HELP", (quantity, gc.getYieldInfo(iYield).getChar()))
-		elif iYield == gc.getInfoTypeForString("YIELD_TRADE_GOODS") or iYield== event.getGenericParameter(2) != gc.getInfoTypeForString("YIELD_LUXURY_GOODS"):
+		elif iYield == gc.getInfoTypeForString("YIELD_TRADE_GOODS") or iYield == gc.getInfoTypeForString("YIELD_LUXURY_GOODS"):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_AFRICA_TRADE_YIELD_AND_TARGET_AMOUNT_HELP_BUY", (quantity, gc.getYieldInfo(iYield).getChar()))
 	szHelp = _appendTradeQuestStandings(szHelp, iYield, TradeLocationTypes.TRADE_LOCATION_AFRICA, gc.getGame().getActivePlayer())
 	return szHelp

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -12397,6 +12397,54 @@ def CanDoEuropeTrade(argsList, iYieldID, iQuantity):
 		return False
 	return True
 
+def _appendTradeQuestStandings(szHelp, iYield, eLocation, eActivePlayer):
+	# Live race standings for first-to-ship-X quests. Sold totals for cargo exports;
+	# bought totals for trade/luxury goods imported from that market.
+	if iYield < 0:
+		return szHelp
+
+	iTradeGoods = gc.getInfoTypeForString("YIELD_TRADE_GOODS")
+	iLuxuryGoods = gc.getInfoTypeForString("YIELD_LUXURY_GOODS")
+	bBuy = (iYield == iTradeGoods or iYield == iLuxuryGoods)
+
+	standings = []
+	for iPlayer in range(gc.getMAX_PLAYERS()):
+		loopPlayer = gc.getPlayer(iPlayer)
+		if loopPlayer is None or loopPlayer.isNone() or not loopPlayer.isAlive():
+			continue
+		if not loopPlayer.isPlayable():
+			continue
+		if loopPlayer.isNative() or loopPlayer.isEurope():
+			continue
+		if gc.getGame().isBarbarianPlayer(iPlayer):
+			continue
+
+		if bBuy:
+			iAmount = loopPlayer.getYieldBoughtTotal(eLocation, iYield)
+		else:
+			iAmount = loopPlayer.getYieldSoldTotal(eLocation, iYield)
+		standings.append((iAmount, iPlayer, loopPlayer))
+
+	if len(standings) == 0:
+		return szHelp
+
+	standings.sort(key=lambda item: (-item[0], item[1]))
+	iLeadAmount = standings[0][0]
+
+	szHelp += localText.getText("TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_HEADER", ())
+	for iAmount, iPlayer, loopPlayer in standings:
+		bYou = (iPlayer == eActivePlayer)
+		bLead = (iAmount == iLeadAmount and iLeadAmount > 0)
+		if bYou and bLead:
+			szHelp += localText.getText("TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_YOU_LEAD", (iAmount,))
+		elif bYou:
+			szHelp += localText.getText("TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_YOU", (iAmount,))
+		elif bLead:
+			szHelp += localText.getText("TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_LEAD", (loopPlayer.getCivilizationShortDescription(0), iAmount))
+		else:
+			szHelp += localText.getText("TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_LINE", (loopPlayer.getCivilizationShortDescription(0), iAmount))
+	return szHelp
+
 # This is the Function for the Event Target Yield and Target Amount
 # This Function is only used for the "Quest Start"
 def getHelpQuestStartEuropeTradeYieldAndAmount(argsList):
@@ -12432,6 +12480,7 @@ def getHelpQuestStartEuropeTradeYieldAndAmount(argsList):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_EUROPE_TRADE_YIELD_AND_TARGET_AMOUNT_HELP", (quantity, gc.getYieldInfo(iYield).getChar()))
 		elif iYield == gc.getInfoTypeForString("YIELD_TRADE_GOODS") or iYield == gc.getInfoTypeForString("YIELD_LUXURY_GOODS"):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_EUROPE_TRADE_YIELD_AND_TARGET_AMOUNT_HELP_BUY", (quantity, gc.getYieldInfo(iYield).getChar()))
+	szHelp = _appendTradeQuestStandings(szHelp, iYield, TradeLocationTypes.TRADE_LOCATION_EUROPE, gc.getGame().getActivePlayer())
 	return szHelp
 
 # This is the Function for the Event Help Text for Price and Attitude
@@ -15190,6 +15239,7 @@ def getHelpQuestStartAfricaTradeYieldAndAmount(argsList):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_AFRICA_TRADE_YIELD_AND_TARGET_AMOUNT_HELP", (quantity, gc.getYieldInfo(iYield).getChar()))
 		elif iYield == gc.getInfoTypeForString("YIELD_TRADE_GOODS") or iYield== event.getGenericParameter(2) != gc.getInfoTypeForString("YIELD_LUXURY_GOODS"):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_AFRICA_TRADE_YIELD_AND_TARGET_AMOUNT_HELP_BUY", (quantity, gc.getYieldInfo(iYield).getChar()))
+	szHelp = _appendTradeQuestStandings(szHelp, iYield, TradeLocationTypes.TRADE_LOCATION_AFRICA, gc.getGame().getActivePlayer())
 	return szHelp
 
 # This is the Function for the Event Help Text for Price and Attitude
@@ -15345,6 +15395,7 @@ def getHelpQuestStartPortRoyalTradeYieldAndAmount(argsList):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_PORTROYAL_TRADE_YIELD_AND_TARGET_AMOUNT_HELP", (quantity, gc.getYieldInfo(iYield).getChar()))
 		elif iYield == gc.getInfoTypeForString("YIELD_TRADE_GOODS") or iYield == gc.getInfoTypeForString("YIELD_LUXURY_GOODS"):
 			szHelp += "\n" + localText.getText("TXT_KEY_EVENT_PORTROYAL_TRADE_YIELD_AND_TARGET_AMOUNT_HELP_BUY", (quantity, gc.getYieldInfo(iYield).getChar()))
+	szHelp = _appendTradeQuestStandings(szHelp, iYield, TradeLocationTypes.TRADE_LOCATION_PORT_ROYAL, gc.getGame().getActivePlayer())
 	return szHelp
 
 # This is the Function for the Event Help Text for Price and Attitude

--- a/Assets/Python/Screens/CvMainInterface.py
+++ b/Assets/Python/Screens/CvMainInterface.py
@@ -2118,7 +2118,7 @@ class CvMainInterface:
 							CitizenHideList.append("PlotDragOn" + str(iPlotIndex))
 
 							# city plot mouse over help - inaiwae - START
-							screen.addDDSGFC("CityPlotInfo" + str(iPlotIndex), "", x-(size_x/32), y-(size_y/4), size_x, size_y, WidgetTypes.WIDGET_CITY_PLOT_INFO, iPlotIndex, -1)
+							screen.addDDSGFC("CityPlotInfo" + str(iPlotIndex), "", x-(size_x/32), y, size_x, size_y, WidgetTypes.WIDGET_CITY_PLOT_INFO, iPlotIndex, -1)
 							CitizenHideList.append("CityPlotInfo" + str(iPlotIndex))
 							# city plot mouse over help - inaiwae - END
 

--- a/Assets/XML/Text/CIV4GameText_Colonization_Events_utf8.xml
+++ b/Assets/XML/Text/CIV4GameText_Colonization_Events_utf8.xml
@@ -4870,6 +4870,41 @@
 		<Russian>[NEWLINE]%s1: %d2 [COLOR_FONT_GOLD](лидер)[COLOR_REVERT]</Russian>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_LOCATION_EUROPE</Tag>
+		<English>Europe</English>
+		<French>Europe</French>
+		<German>Europa</German>
+		<Russian>Европа</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_LOCATION_AFRICA</Tag>
+		<English>Africa</English>
+		<French>Afrique</French>
+		<German>Afrika</German>
+		<Russian>Африка</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_LOCATION_PORT_ROYAL</Tag>
+		<English>Port Royal</English>
+		<French>Port Royal</French>
+		<German>Port Royal</German>
+		<Russian>Порт-Ройал</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_LEADER_YOU</Tag>
+		<English>New leader for %F1_yield (%s2): you now lead with %d3.</English>
+		<French>Nouveau chef de file pour %F1_yield (%s2) : vous êtes maintenant en tête avec %d3.</French>
+		<German>Neue Führung bei %F1_yield (%s2): Ihr führt nun mit %d3.</German>
+		<Russian>Новый лидер по %F1_yield (%s2): теперь вы лидируете с %d3.</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_LEADER_OTHER</Tag>
+		<English>New leader for %F1_yield (%s2): %s3 now leads with %d4.</English>
+		<French>Nouveau chef de file pour %F1_yield (%s2) : %s3 est maintenant en tête avec %d4.</French>
+		<German>Neue Führung bei %F1_yield (%s2): %s3 führt nun mit %d4.</German>
+		<Russian>Новый лидер по %F1_yield (%s2): теперь лидирует %s3 с %d4.</Russian>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_EVENT_EUROPE_TRADE_YIELD_AND_TARGET_AMOUNT_HELP_BUY</Tag>
 		<English>Trade the following quantity of goods from Europe to the colonies [COLOR_FONT_GOLD]before any other nation [COLOR_REVERT]can :[NEWLINE]%D1_amount %F2_yield</English>
 		<French>Acheminez d'Europe vers vos colonies cette quantité de biens [COLOR_FONT_GOLD]avant toute autre nation [COLOR_REVERT]: %D1_amount %F2_yield</French>

--- a/Assets/XML/Text/CIV4GameText_Colonization_Events_utf8.xml
+++ b/Assets/XML/Text/CIV4GameText_Colonization_Events_utf8.xml
@@ -4835,6 +4835,41 @@
 		<Russian>Продайте товар в указанном количестве в Европе [COLOR_FONT_GOLD]прежде, чем другая нация сможет это [COLOR_REVERT]сделать первой :[NEWLINE]%D1_amount %F2_yield</Russian>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_HEADER</Tag>
+		<English>[NEWLINE]Shipments so far:</English>
+		<French>[NEWLINE]Livraisons jusqu'ici :</French>
+		<German>[NEWLINE]Bisher geliefert:</German>
+		<Russian>[NEWLINE]Поставки на данный момент:</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_YOU</Tag>
+		<English>[NEWLINE]You: %d1</English>
+		<French>[NEWLINE]Vous : %d1</French>
+		<German>[NEWLINE]Ihr: %d1</German>
+		<Russian>[NEWLINE]Вы: %d1</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_YOU_LEAD</Tag>
+		<English>[NEWLINE]You: %d1 [COLOR_FONT_GOLD](lead)[COLOR_REVERT]</English>
+		<French>[NEWLINE]Vous : %d1 [COLOR_FONT_GOLD](en tête)[COLOR_REVERT]</French>
+		<German>[NEWLINE]Ihr: %d1 [COLOR_FONT_GOLD](führt)[COLOR_REVERT]</German>
+		<Russian>[NEWLINE]Вы: %d1 [COLOR_FONT_GOLD](лидер)[COLOR_REVERT]</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_LINE</Tag>
+		<English>[NEWLINE]%s1: %d2</English>
+		<French>[NEWLINE]%s1 : %d2</French>
+		<German>[NEWLINE]%s1: %d2</German>
+		<Russian>[NEWLINE]%s1: %d2</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_TRADE_QUEST_STANDINGS_LEAD</Tag>
+		<English>[NEWLINE]%s1: %d2 [COLOR_FONT_GOLD](lead)[COLOR_REVERT]</English>
+		<French>[NEWLINE]%s1 : %d2 [COLOR_FONT_GOLD](en tête)[COLOR_REVERT]</French>
+		<German>[NEWLINE]%s1: %d2 [COLOR_FONT_GOLD](führt)[COLOR_REVERT]</German>
+		<Russian>[NEWLINE]%s1: %d2 [COLOR_FONT_GOLD](лидер)[COLOR_REVERT]</Russian>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_EVENT_EUROPE_TRADE_YIELD_AND_TARGET_AMOUNT_HELP_BUY</Tag>
 		<English>Trade the following quantity of goods from Europe to the colonies [COLOR_FONT_GOLD]before any other nation [COLOR_REVERT]can :[NEWLINE]%D1_amount %F2_yield</English>
 		<French>Acheminez d'Europe vers vos colonies cette quantité de biens [COLOR_FONT_GOLD]avant toute autre nation [COLOR_REVERT]: %D1_amount %F2_yield</French>

--- a/Assets/XML/Text/CIV4GameText_Happiness_utf8.xml
+++ b/Assets/XML/Text/CIV4GameText_Happiness_utf8.xml
@@ -398,11 +398,11 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_CITY_GOLD_STOLEN_BECAUSE_CRIME</Tag>
-		<English>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]The high crime in the city has led to gold being stolen.</English>
-		<French>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]Le taux de crime élevé a entrainé le vol d'argent dans vos coffres.</French>
-		<German>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]Die hohe Kriminalität in der Stadt hat dazu geführt, dass Gold gestohlen wurde.</German>
-		<Russian>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]Высокий уровень преступности в городе привел к краже золота.</Russian>
-		<Hungarian>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]A magas Bűnözés miatt Aranyat loptak a városban.</Hungarian>
+		<English>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]The high crime in the city has led to %d2[ICON_GOLD] being stolen.</English>
+		<French>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]Le taux de crime élevé a entrainé le vol de %d2[ICON_GOLD] dans vos coffres.</French>
+		<German>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]Die hohe Kriminalität in der Stadt hat dazu geführt, dass %d2[ICON_GOLD] gestohlen wurden.</German>
+		<Russian>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]Высокий уровень преступности в городе привел к краже %d2[ICON_GOLD].</Russian>
+		<Hungarian>[COLOR_NEGATIVE_TEXT]%s1_city_name : [COLOR_REVERT]A magas Bűnözés miatt %d2[ICON_GOLD]ot loptak a városban.</Hungarian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_TRAIT_UNHAPPINESS_SLAVES_MODIFIER</Tag>

--- a/Project Files/DLLSources/CvCity.cpp
+++ b/Project Files/DLLSources/CvCity.cpp
@@ -10400,7 +10400,7 @@ void CvCity::doCityCrime()
 		kPlayer.changeGold(-iCityCrime);
 
 		// add message
-		CvWString szBuffer = gDLL->getText("TXT_KEY_CITY_GOLD_STOLEN_BECAUSE_CRIME", getNameKey());
+		CvWString szBuffer = gDLL->getText("TXT_KEY_CITY_GOLD_STOLEN_BECAUSE_CRIME", getNameKey(), iCityCrime);
 		gDLL->UI().addPlayerMessage(eOwner, false, GC.getEVENT_MESSAGE_TIME(), szBuffer, coord(), "AS2D_CITYCRIME", MESSAGE_TYPE_MAJOR_EVENT, ARTFILEMGR.getInterfaceArtInfo("INTERFACE_SHOW_CTIYCRIME")->getPath(), COLOR_RED, true, true);
 
 	}

--- a/Project Files/DLLSources/CvGameTextMgr.cpp
+++ b/Project Files/DLLSources/CvGameTextMgr.cpp
@@ -10153,17 +10153,15 @@ void CvGameTextMgr::setEventHelp(CvWStringBuffer& szBuffer, EventTypes eEvent, i
 
 	CvEventInfo& kEvent = GC.getEventInfo(eEvent);
 	CvPlayer& kActivePlayer = GET_PLAYER(ePlayer);
-	EventTriggeredData* pTriggeredData = kActivePlayer.getEventTriggered(iEventTriggeredId);
-
+	EventTriggeredData* pTriggeredData = NULL;
+	const EventTriggeredData* pOccured = kActivePlayer.getEventOccured(eEvent);
+	if (pOccured != NULL && pOccured->getID() == iEventTriggeredId)
+	{
+		pTriggeredData = const_cast<EventTriggeredData*>(pOccured);
+	}
 	if (NULL == pTriggeredData)
 	{
-		// Quest triggers are deleted after applyEvent. Fall back to the stored quest data
-		// so help/standings can be rebuilt later.
-		const EventTriggeredData* pOccured = kActivePlayer.getEventOccured(eEvent);
-		if (pOccured != NULL && pOccured->getID() == iEventTriggeredId)
-		{
-			pTriggeredData = const_cast<EventTriggeredData*>(pOccured);
-		}
+		pTriggeredData = kActivePlayer.getEventTriggered(iEventTriggeredId);
 	}
 
 	if (NULL == pTriggeredData)

--- a/Project Files/DLLSources/CvGameTextMgr.cpp
+++ b/Project Files/DLLSources/CvGameTextMgr.cpp
@@ -10157,6 +10157,17 @@ void CvGameTextMgr::setEventHelp(CvWStringBuffer& szBuffer, EventTypes eEvent, i
 
 	if (NULL == pTriggeredData)
 	{
+		// Quest triggers are deleted after applyEvent. Fall back to the stored quest data
+		// so help/standings can be rebuilt later.
+		const EventTriggeredData* pOccured = kActivePlayer.getEventOccured(eEvent);
+		if (pOccured != NULL && pOccured->getID() == iEventTriggeredId)
+		{
+			pTriggeredData = const_cast<EventTriggeredData*>(pOccured);
+		}
+	}
+
+	if (NULL == pTriggeredData)
+	{
 		return;
 	}
 

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -8826,30 +8826,6 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn)
 			{
 				// WTP, Schmiddie: Fix for Quest log bug
 				refreshQuestMessages();
-				for (CvEventMap::const_iterator it = m_mapEventsOccured.begin(); it != m_mapEventsOccured.end(); ++it)
-				{
-					const EventTypes eEvent = (*it).first;
-					const EventTriggeredData& kTriggeredData = (*it).second;
-
-					if (GC.getEventInfo(eEvent).isQuest())
-					{
-						const int iID = kTriggeredData.getID();
-						std::map<int, CvWString>::const_iterator itMessage = m_mapQuestMessages.find(iID);
-
-						if (itMessage != m_mapQuestMessages.end())
-						{
-							CvTalkingHeadMessage questMessage(
-								kTriggeredData.m_iTurn + 1,
-								iID,
-								itMessage->second.GetCString(),
-								NULL,
-								MESSAGE_TYPE_QUEST);
-
-							addMessage(questMessage);
-							gDLL->getInterfaceIFace()->dirtyTurnLog(getID());
-						}
-					}
-				}
 			}
 
 			if (getID() == GC.getGameINLINE().getActivePlayer())
@@ -14012,31 +13988,57 @@ void CvPlayer::resetEventOccured(EventTypes eEvent, bool bAnnounce)
 
 void CvPlayer::refreshQuestMessages()
 {
-	for (CvEventMap::const_iterator it = m_mapEventsOccured.begin(); it != m_mapEventsOccured.end(); ++it)
+	CxDesyncMonitor StartAsyncExecution;
+
+	for (CvEventMap::iterator it = m_mapEventsOccured.begin(); it != m_mapEventsOccured.end(); ++it)
 	{
 		const EventTypes eEvent = (*it).first;
-		const EventTriggeredData& kTriggeredData = (*it).second;
-		if (!GC.getEventInfo(eEvent).isQuest())
+		EventTriggeredData& kTriggeredData = (*it).second;
+		CvEventInfo& kEvent = GC.getEventInfo(eEvent);
+		if (!kEvent.isQuest())
 		{
 			continue;
 		}
 
 		CvWStringBuffer szMessageBuffer;
-		szMessageBuffer.append(GC.getEventInfo(eEvent).getDescription());
-		GAMETEXT.setEventHelp(szMessageBuffer, eEvent, kTriggeredData.getID(), getID());
+		szMessageBuffer.append(kEvent.getDescription());
+
+		if (!isEmpty(kEvent.getPythonHelp()))
+		{
+			CvWString szHelp;
+			CyArgsList argsList;
+			argsList.add(gDLL->getPythonIFace()->makePythonObject(&kTriggeredData));
+			argsList.add(eEvent);
+			gDLL->getPythonIFace()->callFunction(PYRandomEventModule, kEvent.getPythonHelp(), argsList.makeFunctionArgs(), &szHelp);
+			szMessageBuffer.append(NEWLINE);
+			szMessageBuffer.append(szHelp);
+		}
 
 		const CvWString szNew = szMessageBuffer.getCString();
 		m_mapQuestMessages[kTriggeredData.getID()] = szNew;
 
 		gDLL->getInterfaceIFace()->addQuestMessage(getID(), szNew, kTriggeredData.getID());
 
-		for (CvMessageQueue::iterator itMessage = m_listGameMessages.begin(); itMessage != m_listGameMessages.end(); ++itMessage)
+		CvMessageQueue::iterator itMessage = m_listGameMessages.begin();
+		while (itMessage != m_listGameMessages.end())
 		{
 			if (itMessage->getLength() == kTriggeredData.getID() && itMessage->getMessageType() == MESSAGE_TYPE_QUEST)
 			{
-				itMessage->setDescription(szNew);
+				itMessage = m_listGameMessages.erase(itMessage);
+			}
+			else
+			{
+				++itMessage;
 			}
 		}
+
+		CvTalkingHeadMessage questMessage(
+			kTriggeredData.m_iTurn + 1,
+			kTriggeredData.getID(),
+			szNew,
+			NULL,
+			MESSAGE_TYPE_QUEST);
+		addMessage(questMessage);
 	}
 
 	gDLL->getInterfaceIFace()->dirtyTurnLog(getID());

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -8825,6 +8825,7 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn)
 			if (getID() == GC.getGameINLINE().getActivePlayer())
 			{
 				// WTP, Schmiddie: Fix for Quest log bug
+				refreshQuestMessages();
 				for (CvEventMap::const_iterator it = m_mapEventsOccured.begin(); it != m_mapEventsOccured.end(); ++it)
 				{
 					const EventTypes eEvent = (*it).first;
@@ -14009,6 +14010,38 @@ void CvPlayer::resetEventOccured(EventTypes eEvent, bool bAnnounce)
 	}
 }
 
+void CvPlayer::refreshQuestMessages()
+{
+	for (CvEventMap::const_iterator it = m_mapEventsOccured.begin(); it != m_mapEventsOccured.end(); ++it)
+	{
+		const EventTypes eEvent = (*it).first;
+		const EventTriggeredData& kTriggeredData = (*it).second;
+		if (!GC.getEventInfo(eEvent).isQuest())
+		{
+			continue;
+		}
+
+		CvWStringBuffer szMessageBuffer;
+		szMessageBuffer.append(GC.getEventInfo(eEvent).getDescription());
+		GAMETEXT.setEventHelp(szMessageBuffer, eEvent, kTriggeredData.getID(), getID());
+
+		const CvWString szNew = szMessageBuffer.getCString();
+		m_mapQuestMessages[kTriggeredData.getID()] = szNew;
+
+		gDLL->getInterfaceIFace()->addQuestMessage(getID(), szNew, kTriggeredData.getID());
+
+		for (CvMessageQueue::iterator itMessage = m_listGameMessages.begin(); itMessage != m_listGameMessages.end(); ++itMessage)
+		{
+			if (itMessage->getLength() == kTriggeredData.getID() && itMessage->getMessageType() == MESSAGE_TYPE_QUEST)
+			{
+				itMessage->setDescription(szNew);
+			}
+		}
+	}
+
+	gDLL->getInterfaceIFace()->dirtyTurnLog(getID());
+}
+
 void CvPlayer::setEventOccured(EventTypes eEvent, const EventTriggeredData& kEventTriggered, bool bOthers)
 {
 	FAssert(eEvent >= 0 && eEvent < GC.getNumEventInfos());
@@ -18897,6 +18930,15 @@ void CvPlayer::changeYieldTradedTaxCounter(TradeLocationTypes eLocation, YieldTy
 		else if (iCount < -MAX)
 		{
 			m_em_iYieldSoldTotal[eLocation].set(eYield, -MAX);
+		}
+	}
+
+	for (int iPlayer = 0; iPlayer < MAX_PLAYERS; ++iPlayer)
+	{
+		CvPlayer& kPlayer = GET_PLAYER((PlayerTypes)iPlayer);
+		if (kPlayer.isAlive() && kPlayer.isHuman())
+		{
+			kPlayer.refreshQuestMessages();
 		}
 	}
 }

--- a/Project Files/DLLSources/CvPlayer.h
+++ b/Project Files/DLLSources/CvPlayer.h
@@ -697,6 +697,7 @@ public:
 	bool isTriggerFired(EventTriggerTypes eEventTrigger) const;
 	void setEventOccured(EventTypes eEvent, const EventTriggeredData& kEventTriggered, bool bOthers = true);
 	void resetEventOccured(EventTypes eEvent, bool bAnnounce = true);
+	void refreshQuestMessages();
 	void setTriggerFired(const EventTriggeredData& kTriggeredData, bool bOthers = true, bool bAnnounce = true);
 	void resetTriggerFired(EventTriggerTypes eEventTrigger);
 	void trigger(EventTriggerTypes eEventTrigger);


### PR DESCRIPTION
## Summary
Two small player-facing readouts that were missing numbers:

1. First-to-ship trade quests only showed the target amount, not who was ahead.
2. High crime removed gold but the city log only said gold was stolen.

## Trade-quest standings (`CvRandomEventInterface.py`)
- Europe, Africa, and Port Royal "first to ship / buy X" quest help now lists each living colonial civ.
- Exports use `getYieldSoldTotal`. Trade goods and luxury goods use `getYieldBoughtTotal`.
- The current leader is marked. Your own line is labeled You.

## Crime gold (`CvCity::doCityCrime`)
- The stolen amount (`iCityCrime`) is passed into `TXT_KEY_CITY_GOLD_STOLEN_BECAUSE_CRIME`.
- English/French/German/Russian/Hungarian texts show `%d2[ICON_GOLD]`.

## Test plan
- [x] Change is Python + one DLL text argument. Compiled FinalRelease locally with this plus other playtest work.
- [ ] Start a first-to-ship Europe/Africa/Port Royal quest: hover/help lists standings.
- [ ] Trade goods / luxury goods quests show bought totals, not sold.
- [ ] High-crime city: log shows how much gold was stolen.
- [ ] Existing saves: no save-format change.

## Notes
- Crime line needs a rebuilt `CvGameCoreDLL.dll`. The compiled binary is gitignored and is not in this PR.
- Trade standings apply after a game restart (Python).
- Local compile helper `compile_finalrelease.bat` is not included.