### PR TITLE
Send rewarded ships to Europe if the capital has no ocean access

### DIFF
--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -5491,28 +5491,12 @@ def _cityHasEuropeAccess(city):
 	return False
 
 def _cityHasAdjacentOceanPlot(city):
-	# Deep-water berth: ocean or coast. Lake, great river and shallow coast are not enough.
+	# True if the city can sail to Europe: adjacent coast that reaches the ocean.
+	# Closed lakes and inner seas fail this. Great river alone fails this.
 	if city is None or city.isNone():
 		return False
 
-	iOcean = gc.getInfoTypeForString("TERRAIN_OCEAN")
-	iCoast = gc.getInfoTypeForString("TERRAIN_COAST")
-
-	for iDirection in range(DirectionTypes.NUM_DIRECTION_TYPES):
-		pAdjacentPlot = plotDirection(
-			city.getX(),
-			city.getY(),
-			DirectionTypes(iDirection)
-		)
-
-		if pAdjacentPlot is None or pAdjacentPlot.isNone():
-			continue
-
-		eTerrain = pAdjacentPlot.getTerrainType()
-		if eTerrain == iOcean or eTerrain == iCoast:
-			return True
-
-	return False
+	return city.isEuropeAccessable()
 
 def _unitOnCityPlot(player, city, iUnitClass):
 	if player is None or player.isNone() or city is None or city.isNone():
@@ -5536,38 +5520,77 @@ def _unitOnCityPlot(player, city, iUnitClass):
 
 	return None
 
+def _spawnRewardedShipInEurope(player, iUnitClass):
+	# Ships bought in Europe are NOT initEuropeUnit (that is the colonist dock).
+	# They stay in the player unit list with IN_EUROPE so the harbor row can see them.
+	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
+	if iUnitType == -1:
+		return None
+
+	unit = player.initUnit(
+		iUnitType,
+		gc.getUnitInfo(iUnitType).getDefaultProfession(),
+		-1,
+		-1,
+		UnitAITypes.NO_UNITAI,
+		DirectionTypes.NO_DIRECTION,
+		0
+	)
+	if unit is None or unit.isNone():
+		return None
+
+	unit.setUnitTravelState(UnitTravelStates.UNIT_TRAVEL_STATE_IN_EUROPE, False)
+	return unit
+
+def _getCapitalIfCanReceiveShip(player):
+	if player is None or player.isNone():
+		return None
+
+	capital = player.getCapitalCity()
+	if capital is None or capital.isNone():
+		return None
+
+	if _cityHasAdjacentOceanPlot(capital):
+		return capital
+
+	return None
+
 def _spawnRewardedShip(player, iUnitClass, city=None):
-	# Preferred city if it has adjacent ocean/coast.
-	# Else first city with adjacent ocean/coast.
-	# Else still spawn in the preferred/first city so the ship cannot vanish.
-	# Europe only if the player has no city at all.
-	# Returns the created unit when we can find it (for named ships).
+	# Capital first if it can sail to Europe.
+	# Else the preferred city, if it can.
+	# Else any other city that can sail to Europe.
+	# Else Europe harbor (same path as buying a ship there).
+	# Else last resort: any city so the unit cannot vanish.
 	# Do not use this for events that must wait for a colonial port
 	# (for example CommandeeredReturn).
 	if player is None or player.isNone() or iUnitClass == -1:
 		return None
 
-	pCity = None
-	if city is not None and not city.isNone() and _cityHasAdjacentOceanPlot(city):
-		pCity = city
-	else:
-		pCity = getFirstOceanAccessCity(player)
-
-	if pCity is None or pCity.isNone():
-		if city is not None and not city.isNone():
+	pCity = _getCapitalIfCanReceiveShip(player)
+	if pCity is None:
+		if city is not None and not city.isNone() and _cityHasAdjacentOceanPlot(city):
 			pCity = city
 		else:
-			(pCity, iter) = player.firstCity(False)
+			pCity = getFirstOceanAccessCity(player)
 
 	if pCity is not None and not pCity.isNone():
 		pCity.spawnOwnPlayerUnitOnPlotOfCity(iUnitClass)
 		return _unitOnCityPlot(player, pCity, iUnitClass)
 
-	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
-	if iUnitType == -1:
-		return None
+	unit = _spawnRewardedShipInEurope(player, iUnitClass)
+	if unit is not None and not unit.isNone():
+		return unit
 
-	return player.initEuropeUnit(iUnitType, UnitAITypes.NO_UNITAI, DirectionTypes.NO_DIRECTION)
+	if city is not None and not city.isNone():
+		pCity = city
+	else:
+		(pCity, iter) = player.firstCity(False)
+
+	if pCity is not None and not pCity.isNone():
+		pCity.spawnOwnPlayerUnitOnPlotOfCity(iUnitClass)
+		return _unitOnCityPlot(player, pCity, iUnitClass)
+
+	return None
 
 def _countPiratesTreasureCities(player):
 	if player is None or player.isNone():
@@ -27967,17 +27990,20 @@ def getHelpThreeGalleonsRewardShip(argsList):
 ######## Event six war ships ###########
 
 def getFirstOceanAccessCity(player):
-	if player.isNone():
+	if player is None or player.isNone():
 		return None
 
-	(city, iter) = player.firstCity(True)
+	capital = _getCapitalIfCanReceiveShip(player)
+	if capital is not None:
+		return capital
+
+	(city, iter) = player.firstCity(False)
 
 	while city:
-		if not city.isNone():
-			if _cityHasAdjacentOceanPlot(city):
-				return city
+		if not city.isNone() and _cityHasAdjacentOceanPlot(city):
+			return city
 
-		(city, iter) = player.nextCity(iter, True)
+		(city, iter) = player.nextCity(iter, False)
 
 	return None
 

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -5482,9 +5482,36 @@ def _cityHasEuropeAccess(city):
 	if city is None or city.isNone():
 		return False
 
-	# Real ocean/coast only. Lakes and great rivers can be water, but ships
-	# cannot sail from them to Europe.
-	return city.isEuropeAccessable()
+	if city.isCoastal(gc.getMIN_WATER_SIZE_FOR_OCEAN()):
+		return True
+
+	if _plotHasAdjacentSeaWater(city.plot()):
+		return True
+
+	return False
+
+def _cityHasAdjacentOceanPlot(city):
+	if city is None or city.isNone():
+		return False
+
+	iOcean = gc.getInfoTypeForString("TERRAIN_OCEAN")
+	if iOcean == -1:
+		return False
+
+	for iDirection in range(DirectionTypes.NUM_DIRECTION_TYPES):
+		pAdjacentPlot = plotDirection(
+			city.getX(),
+			city.getY(),
+			DirectionTypes(iDirection)
+		)
+
+		if pAdjacentPlot is None or pAdjacentPlot.isNone():
+			continue
+
+		if pAdjacentPlot.getTerrainType() == iOcean:
+			return True
+
+	return False
 
 def _unitClassIsNaval(player, iUnitClass):
 	if player is None or player.isNone() or iUnitClass == -1:
@@ -5496,15 +5523,31 @@ def _unitClassIsNaval(player, iUnitClass):
 
 	return gc.getUnitInfo(iUnitType).getDomainType() == DomainTypes.DOMAIN_SEA
 
+def _initOwnPlayerUnit(player, iUnitClass, iX, iY):
+	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
+	if iUnitType == -1:
+		return None
+
+	# spawnOwnPlayerUnitOnPlotOfCity is void; initUnit returns the created unit
+	# so callers can name Queen Anne's Revenge / Black Pearl in both spawn paths.
+	return player.initUnit(
+		iUnitType,
+		gc.getUnitInfo(iUnitType).getDefaultProfession(),
+		iX,
+		iY,
+		UnitAITypes.NO_UNITAI,
+		DirectionTypes.NO_DIRECTION,
+		0
+	)
+
 def _spawnRewardedShip(player, iUnitClass, city=None):
-	# Spawn a rewarded ship on the destination city only if that city has
-	# ocean access. Otherwise send it to Europe.
+	# Spawn a rewarded ship on a city with an adjacent ocean plot.
+	# Otherwise send it to Europe. Returns the created unit in both cases.
 	if player is None or player.isNone() or iUnitClass == -1:
 		return None
 
-	if city is not None and not city.isNone() and _cityHasEuropeAccess(city):
-		city.spawnOwnPlayerUnitOnPlotOfCity(iUnitClass)
-		return None
+	if city is not None and not city.isNone() and _cityHasAdjacentOceanPlot(city):
+		return _initOwnPlayerUnit(player, iUnitClass, city.getX(), city.getY())
 
 	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
 	if iUnitType == -1:
@@ -27920,7 +27963,7 @@ def getFirstOceanAccessCity(player):
 
 	while city:
 		if not city.isNone():
-			if _cityHasEuropeAccess(city):
+			if _cityHasAdjacentOceanPlot(city):
 				return city
 
 		(city, iter) = player.nextCity(iter, True)
@@ -28307,7 +28350,12 @@ def applyCommandeeredReturn(argsList):
 	if iUnitClass == -1:
 		return
 
-	_spawnRewardedShip(player, iUnitClass, getFirstOceanAccessCity(player))
+	city = getFirstOceanAccessCity(player)
+
+	if city is None or city.isNone():
+		return
+
+	city.spawnOwnPlayerUnitOnPlotOfCity(iUnitClass)
 
 	_clearCommandeeredShipClass(player)
 

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -5491,12 +5491,12 @@ def _cityHasEuropeAccess(city):
 	return False
 
 def _cityHasAdjacentOceanPlot(city):
+	# Deep-water berth: ocean or coast. Lake, great river and shallow coast are not enough.
 	if city is None or city.isNone():
 		return False
 
 	iOcean = gc.getInfoTypeForString("TERRAIN_OCEAN")
-	if iOcean == -1:
-		return False
+	iCoast = gc.getInfoTypeForString("TERRAIN_COAST")
 
 	for iDirection in range(DirectionTypes.NUM_DIRECTION_TYPES):
 		pAdjacentPlot = plotDirection(
@@ -5508,34 +5508,40 @@ def _cityHasAdjacentOceanPlot(city):
 		if pAdjacentPlot is None or pAdjacentPlot.isNone():
 			continue
 
-		if pAdjacentPlot.getTerrainType() == iOcean:
+		eTerrain = pAdjacentPlot.getTerrainType()
+		if eTerrain == iOcean or eTerrain == iCoast:
 			return True
 
 	return False
 
-def _initOwnPlayerUnit(player, iUnitClass, iX, iY):
-	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
-	if iUnitType == -1:
+def _unitOnCityPlot(player, city, iUnitClass):
+	if player is None or player.isNone() or city is None or city.isNone():
 		return None
 
-	# spawnOwnPlayerUnitOnPlotOfCity is void; initUnit returns the created unit
-	# so callers can name Queen Anne's Revenge / Black Pearl in both spawn paths.
-	return player.initUnit(
-		iUnitType,
-		gc.getUnitInfo(iUnitType).getDefaultProfession(),
-		iX,
-		iY,
-		UnitAITypes.NO_UNITAI,
-		DirectionTypes.NO_DIRECTION,
-		0
-	)
+	pPlot = city.plot()
+	if pPlot is None or pPlot.isNone():
+		return None
+
+	eOwner = player.getID()
+	i = 0
+	while i < pPlot.getNumUnits():
+		pUnit = pPlot.getUnit(i)
+		i += 1
+		if pUnit is None or pUnit.isNone():
+			continue
+		if pUnit.getOwner() != eOwner:
+			continue
+		if pUnit.getUnitClassType() == iUnitClass:
+			return pUnit
+
+	return None
 
 def _spawnRewardedShip(player, iUnitClass, city=None):
-	# Normal rewarded ship:
-	#   preferred city if it has adjacent TERRAIN_OCEAN
-	#   else first city with adjacent TERRAIN_OCEAN
-	#   else Europe
-	# Returns the created unit in both the city and Europe paths.
+	# Preferred city if it has adjacent ocean/coast.
+	# Else first city with adjacent ocean/coast.
+	# Else still spawn in the preferred/first city so the ship cannot vanish.
+	# Europe only if the player has no city at all.
+	# Returns the created unit when we can find it (for named ships).
 	# Do not use this for events that must wait for a colonial port
 	# (for example CommandeeredReturn).
 	if player is None or player.isNone() or iUnitClass == -1:
@@ -5547,8 +5553,15 @@ def _spawnRewardedShip(player, iUnitClass, city=None):
 	else:
 		pCity = getFirstOceanAccessCity(player)
 
+	if pCity is None or pCity.isNone():
+		if city is not None and not city.isNone():
+			pCity = city
+		else:
+			(pCity, iter) = player.firstCity(False)
+
 	if pCity is not None and not pCity.isNone():
-		return _initOwnPlayerUnit(player, iUnitClass, pCity.getX(), pCity.getY())
+		pCity.spawnOwnPlayerUnitOnPlotOfCity(iUnitClass)
+		return _unitOnCityPlot(player, pCity, iUnitClass)
 
 	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
 	if iUnitType == -1:

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -4082,12 +4082,7 @@ def applyAntiPirateRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = getFirstOceanAccessCity(player)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, getFirstOceanAccessCity(player))
 
 
 def getHelpAntiPirateRewardShip(argsList):
@@ -5484,16 +5479,38 @@ def _plotHasAdjacentSeaWater(plot):
 	return False
 
 def _cityHasEuropeAccess(city):
-	if city.isNone():
+	if city is None or city.isNone():
 		return False
 
-	if city.isCoastal(gc.getMIN_WATER_SIZE_FOR_OCEAN()):
-		return True
+	# Real ocean/coast only. Lakes and great rivers can be water, but ships
+	# cannot sail from them to Europe.
+	return city.isEuropeAccessable()
 
-	if _plotHasAdjacentSeaWater(city.plot()):
-		return True
+def _unitClassIsNaval(player, iUnitClass):
+	if player is None or player.isNone() or iUnitClass == -1:
+		return False
 
-	return False
+	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
+	if iUnitType == -1:
+		return False
+
+	return gc.getUnitInfo(iUnitType).getDomainType() == DomainTypes.DOMAIN_SEA
+
+def _spawnRewardedShip(player, iUnitClass, city=None):
+	# Spawn a rewarded ship on the destination city only if that city has
+	# ocean access. Otherwise send it to Europe.
+	if player is None or player.isNone() or iUnitClass == -1:
+		return None
+
+	if city is not None and not city.isNone() and _cityHasEuropeAccess(city):
+		city.spawnOwnPlayerUnitOnPlotOfCity(iUnitClass)
+		return None
+
+	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
+	if iUnitType == -1:
+		return None
+
+	return player.initEuropeUnit(iUnitType, UnitAITypes.NO_UNITAI, DirectionTypes.NO_DIRECTION)
 
 def _countPiratesTreasureCities(player):
 	if player is None or player.isNone():
@@ -7329,12 +7346,7 @@ def applyPrivateerRewardShip3(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = getFirstOceanAccessCity(player)
-
-	if city is None or city.isNone():
-		return
-
-	unit = city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	unit = _spawnRewardedShip(player, iRewardUnitClass, getFirstOceanAccessCity(player))
 
 	if unit is not None and not unit.isNone():
 		unit.setName("Queen Anne's Revenge")
@@ -7388,12 +7400,7 @@ def applyPrivateerRewardShip4(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = getFirstOceanAccessCity(player)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, getFirstOceanAccessCity(player))
 
 
 def getHelpPrivateerRewardShip4(argsList):
@@ -17095,7 +17102,10 @@ def spawnOwnPlayerUnitOnSamePlotAsCity(argsList):
 	iOwnUnitClassTypeToSpawn = event.getGenericParameter(1)
 	iNumOwnToSpawn = event.getGenericParameter(2)
 	for iX in range(iNumOwnToSpawn):
-		city.spawnOwnPlayerUnitOnPlotOfCity(iOwnUnitClassTypeToSpawn)
+		if _unitClassIsNaval(player, iOwnUnitClassTypeToSpawn):
+			_spawnRewardedShip(player, iOwnUnitClassTypeToSpawn, city)
+		else:
+			city.spawnOwnPlayerUnitOnPlotOfCity(iOwnUnitClassTypeToSpawn)
 
 # adjacent Plot
 def spawnOwnPlayerUnitAdjacentToCity(argsList):
@@ -20887,12 +20897,11 @@ def applyFourTreasuresRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	(city, iter) = player.firstCity(True)
-
+	city = player.getCapitalCity()
 	if city is None or city.isNone():
-		return
+		(city, iter) = player.firstCity(True)
 
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpFourTreasuresRewardShip(argsList):
@@ -21081,7 +21090,7 @@ def applyFourTreasuresReturnBuy(argsList):
 
 	player.changeGold(-FOUR_TREASURES_RETURN_REQUIRED_GOLD)
 
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 	_changeKingRelation(argsList, 1)
 	_clearFourTreasuresState(player)
@@ -27873,12 +27882,11 @@ def applyThreeGalleonsRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	(city, iter) = player.firstCity(True)
-
+	city = player.getCapitalCity()
 	if city is None or city.isNone():
-		return
+		(city, iter) = player.firstCity(True)
 
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpThreeGalleonsRewardShip(argsList):
@@ -27976,12 +27984,7 @@ def applySixWarshipsRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = getFirstOceanAccessCity(player)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, getFirstOceanAccessCity(player))
 
 
 def getHelpSixWarshipsRewardShip(argsList):
@@ -28097,12 +28100,7 @@ def applyFiveDocksRewardShip2(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = getFirstOceanAccessCity(player)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, getFirstOceanAccessCity(player))
 
 
 def applyFiveDocksRewardShip3(argsList):
@@ -28117,12 +28115,7 @@ def applyFiveDocksRewardShip3(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = getFirstOceanAccessCity(player)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, getFirstOceanAccessCity(player))
 
 
 def getHelpFiveDocksRewardShip2(argsList):
@@ -28314,12 +28307,7 @@ def applyCommandeeredReturn(argsList):
 	if iUnitClass == -1:
 		return
 
-	city = getFirstOceanAccessCity(player)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iUnitClass)
+	_spawnRewardedShip(player, iUnitClass, getFirstOceanAccessCity(player))
 
 	_clearCommandeeredShipClass(player)
 
@@ -28403,10 +28391,7 @@ def applyAfricaTradeQuestRewardShip(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpAfricaTradeQuestRewardShip(argsList):
@@ -28463,11 +28448,8 @@ def applyFiveCathedralsRewardShips3(argsList):
 
 	city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
 	for i in range(2):
-		city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+		_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpFiveCathedralsRewardShips3(argsList):
@@ -28509,10 +28491,7 @@ def applyPiratesRewardShip4a(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	unit = city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	unit = _spawnRewardedShip(player, iRewardUnitClass, city)
 
 	if unit is not None and not unit.isNone():
 		unit.setName("Black Pearl")
@@ -28573,10 +28552,7 @@ def applyEuropeTradeQuestRewardShip10(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpEuropeTradeQuestRewardShip10(argsList):
@@ -28638,10 +28614,7 @@ def applyEuropeTradeQuestRewardShip11(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpEuropeTradeQuestRewardShip11(argsList):
@@ -28703,10 +28676,7 @@ def applyEuropeTradeQuestRewardShipMuskets(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpEuropeTradeQuestRewardShipMuskets(argsList):
@@ -28767,10 +28737,7 @@ def applyEuropeTradeQuestRewardShipRope(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 def getHelpEuropeTradeQuestRewardShipRope(argsList):
 	kTriggeredData = argsList[0]
@@ -28831,10 +28798,7 @@ def applyEuropeTradeQuestRewardShipHardwood(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpEuropeTradeQuestRewardShipHardwood(argsList):
@@ -28896,10 +28860,7 @@ def applyPortRoyalTradeQuestRewardShip3(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpPortRoyalTradeQuestRewardShip3(argsList):
@@ -28961,10 +28922,7 @@ def applyPortRoyalTradeQuestRewardShip4(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpPortRoyalTradeQuestRewardShip4(argsList):
@@ -29025,10 +28983,7 @@ def applyCibolaExpeditionArrival2RewardShip(argsList):
 	if city is None or city.isNone():
 		city = getFirstOceanAccessCity(player)
 
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass, city)
 
 
 def getHelpCibolaExpeditionArrival2RewardShip(argsList):

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -5513,16 +5513,6 @@ def _cityHasAdjacentOceanPlot(city):
 
 	return False
 
-def _unitClassIsNaval(player, iUnitClass):
-	if player is None or player.isNone() or iUnitClass == -1:
-		return False
-
-	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
-	if iUnitType == -1:
-		return False
-
-	return gc.getUnitInfo(iUnitType).getDomainType() == DomainTypes.DOMAIN_SEA
-
 def _initOwnPlayerUnit(player, iUnitClass, iX, iY):
 	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
 	if iUnitType == -1:
@@ -5541,13 +5531,24 @@ def _initOwnPlayerUnit(player, iUnitClass, iX, iY):
 	)
 
 def _spawnRewardedShip(player, iUnitClass, city=None):
-	# Spawn a rewarded ship on a city with an adjacent ocean plot.
-	# Otherwise send it to Europe. Returns the created unit in both cases.
+	# Normal rewarded ship:
+	#   preferred city if it has adjacent TERRAIN_OCEAN
+	#   else first city with adjacent TERRAIN_OCEAN
+	#   else Europe
+	# Returns the created unit in both the city and Europe paths.
+	# Do not use this for events that must wait for a colonial port
+	# (for example CommandeeredReturn).
 	if player is None or player.isNone() or iUnitClass == -1:
 		return None
 
+	pCity = None
 	if city is not None and not city.isNone() and _cityHasAdjacentOceanPlot(city):
-		return _initOwnPlayerUnit(player, iUnitClass, city.getX(), city.getY())
+		pCity = city
+	else:
+		pCity = getFirstOceanAccessCity(player)
+
+	if pCity is not None and not pCity.isNone():
+		return _initOwnPlayerUnit(player, iUnitClass, pCity.getX(), pCity.getY())
 
 	iUnitType = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iUnitClass)
 	if iUnitType == -1:
@@ -17145,10 +17146,7 @@ def spawnOwnPlayerUnitOnSamePlotAsCity(argsList):
 	iOwnUnitClassTypeToSpawn = event.getGenericParameter(1)
 	iNumOwnToSpawn = event.getGenericParameter(2)
 	for iX in range(iNumOwnToSpawn):
-		if _unitClassIsNaval(player, iOwnUnitClassTypeToSpawn):
-			_spawnRewardedShip(player, iOwnUnitClassTypeToSpawn, city)
-		else:
-			city.spawnOwnPlayerUnitOnPlotOfCity(iOwnUnitClassTypeToSpawn)
+		city.spawnOwnPlayerUnitOnPlotOfCity(iOwnUnitClassTypeToSpawn)
 
 # adjacent Plot
 def spawnOwnPlayerUnitAdjacentToCity(argsList):

--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -5498,6 +5498,41 @@ def _cityHasAdjacentOceanPlot(city):
 
 	return city.isEuropeAccessable()
 
+def _cityHasCoastOrOcean(city):
+	# Adjacent coast or ocean. Lake and great river do not count.
+	if city is None or city.isNone():
+		return False
+
+	iOcean = gc.getInfoTypeForString("TERRAIN_OCEAN")
+	iCoast = gc.getInfoTypeForString("TERRAIN_COAST")
+
+	for iDirection in range(DirectionTypes.NUM_DIRECTION_TYPES):
+		pAdjacentPlot = plotDirection(
+			city.getX(),
+			city.getY(),
+			DirectionTypes(iDirection)
+		)
+		if pAdjacentPlot is None or pAdjacentPlot.isNone():
+			continue
+		eTerrain = pAdjacentPlot.getTerrainType()
+		if eTerrain == iOcean or eTerrain == iCoast:
+			return True
+
+	return False
+
+def _getCapitalCity(player):
+	# Walk the city list. getCapitalCity() is manage_new_object and is easy to drop.
+	if player is None or player.isNone():
+		return None
+
+	(city, iter) = player.firstCity(False)
+	while city:
+		if not city.isNone() and city.isCapital():
+			return city
+		(city, iter) = player.nextCity(iter, False)
+
+	return None
+
 def _unitOnCityPlot(player, city, iUnitClass):
 	if player is None or player.isNone() or city is None or city.isNone():
 		return None
@@ -5543,14 +5578,14 @@ def _spawnRewardedShipInEurope(player, iUnitClass):
 	return unit
 
 def _getCapitalIfCanReceiveShip(player):
-	if player is None or player.isNone():
+	capital = _getCapitalCity(player)
+	if capital is None:
 		return None
 
-	capital = player.getCapitalCity()
-	if capital is None or capital.isNone():
-		return None
-
-	if _cityHasAdjacentOceanPlot(capital):
+	# Capital on real sea: Europe-access, or adjacent coast/ocean.
+	# Do not require isEuropeAccessable() alone; that check ignores
+	# a city that only touches TERRAIN_OCEAN.
+	if _cityHasAdjacentOceanPlot(capital) or _cityHasCoastOrOcean(capital):
 		return capital
 
 	return None
@@ -20974,11 +21009,7 @@ def applyFourTreasuresRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = player.getCapitalCity()
-	if city is None or city.isNone():
-		(city, iter) = player.firstCity(True)
-
-	_spawnRewardedShip(player, iRewardUnitClass, city)
+	_spawnRewardedShip(player, iRewardUnitClass)
 
 
 def getHelpFourTreasuresRewardShip(argsList):
@@ -27959,11 +27990,7 @@ def applyThreeGalleonsRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	city = player.getCapitalCity()
-	if city is None or city.isNone():
-		(city, iter) = player.firstCity(True)
-
-	_spawnRewardedShip(player, iRewardUnitClass, city)
+	_spawnRewardedShip(player, iRewardUnitClass)
 
 
 def getHelpThreeGalleonsRewardShip(argsList):


### PR DESCRIPTION
Rewarded ships (king offers, quest rewards, etc.) no longer spawn on a lake or inner sea, and they no longer vanish.

**Where the ship appears**
1. **Capital**, if that city can sail to Europe (`isEuropeAccessable()`: coast that reaches the ocean).
2. Else the preferred city from the event, if it can.
3. Else any other city that can sail to Europe.
4. Else **Europe harbor**, using the same path as buying a ship there (not `initEuropeUnit`, which is the colonist dock and hid the galleon).
5. Else any city, so the unit cannot disappear.

Great river or lake alone is not enough. Closed inner seas fail `isEuropeAccessable()`.

Commandeered Return is unchanged: it still waits for a colonial ocean-access port.

Text/Python only. Restart the game. No DLL rebuild.