### PR TITLE
Stop Python log crashes on city names with accents

### DIFF
--- a/Assets/Python/CvUtil.py
+++ b/Assets/Python/CvUtil.py
@@ -152,13 +152,22 @@ def myExceptHook(type, value, tb):
 	#total = pre+mid+post
 	total=mid
 	if SHOWEXCEPTIONS:
-		sys.stderr.write(total)
+		sys.stderr.write(_toAsciiLog(total))
 	else:
-		sys.stdout.write(total)
+		sys.stdout.write(_toAsciiLog(total))
+
+def _toAsciiLog(stuff):
+	if stuff is None:
+		return ""
+	if isinstance(stuff, unicode):
+		return stuff.encode("ascii", "replace")
+	try:
+		return str(stuff)
+	except Exception:
+		return repr(stuff)
 
 def pyPrint(stuff):
-	stuff = 'PY:' + stuff + "\n"
-	sys.stdout.write(stuff)
+	sys.stdout.write('PY:' + _toAsciiLog(stuff) + "\n")
 
 def pyAssert(cond, msg):
 	if (cond==False):


### PR DESCRIPTION
`onCityGrowth` logs the city name through `CvUtil.pyPrint`. Python 2.4 then writes that string to an ascii stdout. If the name has a character like e-acute (Quebec, etc.), the player gets a stack of `UnicodeEncodeError` popups. Alt-tabbing back into the game is when the queued growth event often fires, so it looks like a focus bug. It is just the log line.

This encodes debug output as ascii with `?` for non-ascii letters. The city still grows. Gameplay is unchanged.

Python only. Restart the game to pick it up. No DLL rebuild.