### PR TITLE
Let the owner's buccaneer board their own ships

### DIFF
--- a/Project Files/DLLSources/CvUnit.cpp
+++ b/Project Files/DLLSources/CvUnit.cpp
@@ -3919,14 +3919,20 @@ bool CvUnit::canMoveInto(CvPlot const& kPlot, bool bAttack, bool bDeclareWar, bo
 	{
 		if (bAttack || !canCoexistWithEnemyUnit(NO_TEAM))
 		{
-			if (!isHuman() || (kPlot.isVisible(getTeam(), false)))
+			// Prefer boarding our own ship over attacking a rival on the
+			// same plot (issue #877).
+			const bool bBoarding = !bAttack && !bIgnoreLoad && canLoad(&kPlot, false);
+			if (!bBoarding)
 			{
-				if (kPlot.isVisibleEnemyUnit(this) != bAttack)
+				if (!isHuman() || (kPlot.isVisible(getTeam(), false)))
 				{
-					//FAssertMsg(isHuman() || (!bDeclareWar || (pPlot->isVisibleOtherUnit(getOwnerINLINE()) != bAttack)), "hopefully not an issue, but tracking how often this is the case when we dont want to really declare war");
-					if (!bDeclareWar || (kPlot.isVisibleOtherUnit(getOwnerINLINE()) != bAttack && !(bAttack && kPlot.getPlotCity() && !isNoCityCapture())))
+					if (kPlot.isVisibleEnemyUnit(this) != bAttack)
 					{
-						return false;
+						//FAssertMsg(isHuman() || (!bDeclareWar || (pPlot->isVisibleOtherUnit(getOwnerINLINE()) != bAttack)), "hopefully not an issue, but tracking how often this is the case when we dont want to really declare war");
+						if (!bDeclareWar || (kPlot.isVisibleOtherUnit(getOwnerINLINE()) != bAttack && !(bAttack && kPlot.getPlotCity() && !isNoCityCapture())))
+						{
+							return false;
+						}
 					}
 				}
 			}
@@ -4679,15 +4685,11 @@ bool CvUnit::canLoadUnit(const CvUnit* pTransport, const CvPlot* pPlot, bool bCh
 		return false;
 	}
 
-	// Prohibit a unit with hidden nationality from boarding a non-hidden nat. transport
-	// This also fixes the bug that allows buccanneers to attack a ship if a friendly ship is 
-	// present on the same plot (see #877)
-	if (m_pUnitInfo->getDefaultUnitAIType() != UNITAI_YIELD &&
-		m_pUnitInfo->isHiddenNationality() &&
-		!pTransport->getUnitInfo().isHiddenNationality())
-	{
-		return false;
-	}
+	// Hidden nationality is hidden from other civs, not from the owner.
+	// Same-team is already required above, so the owner's buccaneer may
+	// board any of their ships. The old ban on non-HN transports was a
+	// workaround for #877 (attacking a rival on the same coastal plot
+	// instead of boarding). That case is handled in canMoveInto.
 
 	return true;
 }


### PR DESCRIPTION
A buccaneer is hidden nationality for **other players**, not for its owner. After #877 the unit could not board a normal Caravel (or any non-HN transport), so you could not move your own buccaneer on your own ship.

## Change
- `CvUnit::canLoadUnit`: drop the blanket ban on HN land units boarding a non-HN transport. Same-team is already required, so this is the owner's fleet only.
- `CvUnit::canMoveInto`: if the move is a load onto our ship, do not treat a rival on the same coastal plot as a forced attack. That was the original #877 case (buccaneer + friendly transport + rival ship). Boarding wins; a plot with only enemies still attacks.

## Test plan
- [ ] Buccaneer loads onto the owner's Caravel / merchantman (same team, not a pirate hull).
- [ ] Buccaneer still cannot board a **foreign** ship.
- [ ] Coastal tile with **our** transport and a **rival** ship: moving the buccaneer onto it boards, it does not suicide-attack the rival.
- [ ] Coastal tile with **only** a rival ship: buccaneer still attacks as before.

## Notes
- DLL change. Rebuilt FinalRelease locally. Binary is gitignored and is not in this PR.
- Isolated from teaching / gift work.