### PR TITLE
Stop Inland Seas from consuming large flat areas

### DIFF
--- a/PrivateMaps/FaireWeatherTweakEx.py
+++ b/PrivateMaps/FaireWeatherTweakEx.py
@@ -3883,7 +3883,7 @@ class RiverMap :
             (height,x,y,idx)=k.getLowestBorder()
             ii = GetIndex(x,y)
             
-            if height < k.waterH:
+            if height <= k.waterH:
                 # drainage pathway found! Lake finished
                 print("Drainage found at %i %i: %i" % (x,y, ii))
                 self.lakeMap[ii] = self.lakeExit


### PR DESCRIPTION
It seems to be a common complaint that inland seas are far too common with the current map script. When investigating a way to reduce the number created, I discovered the cause. The function that generates lakes is designed so that you give it a local minimum, and it fills up the basin that minimum is in until it can overflow and flow to the ocean. However, it treats large flat areas as basins, which is what causes the inland seas. They are simply large flat areas that have a single low point, and the lake in that low point consumes the entire region, submerging it. 
It appears to have been a simple case of the wrong comparison operator, so this PR fixes that.

As a side benefit, this restores large plains to the map script, as they were previously extremely likely to be consumed by inland seas.