### PR TITLE
Revert "Return -1 instead of raw index when ConvertIndex lookup fails"

### DIFF
--- a/Project Files/DLLSources/CvSavegame.cpp
+++ b/Project Files/DLLSources/CvSavegame.cpp
@@ -539,7 +539,7 @@ int CvSavegameReader::ConvertIndex(JITarrayTypes eType, int iIndex) const
 		}
 	}
 
-	return -1;
+	return iIndex;
 }
 
 int CvSavegameReader::GetXmlSize(JITarrayTypes eType) const


### PR DESCRIPTION
Reverts We-the-People-civ4col-mod/Mod#1234

Unfortunately I had to revert this change after testing it with existing savegames.

Returning `-1` in this fallback path causes widespread savegame loading issues and crashes. Apparently this path also covers cases where preserving the raw index is required, so it cannot be treated in the same way as an XML entry which has actually been removed.

The underlying concern may still be valid, but we will need a more targeted solution which distinguishes between these cases.

