### PR TITLE
Jump to native villages from the domestic advisor row icon

### DIFF
--- a/Assets/Python/Screens/Domestic Advisor/NativeAdvisor.py
+++ b/Assets/Python/Screens/Domestic Advisor/NativeAdvisor.py
@@ -23,12 +23,6 @@ class NativeAdvisor(BaseAdvisorWindow.BaseAdvisorWindow):
 		self.tradeStationChar = gc.getYieldInfo(YieldTypes.YIELD_TRADE_GOODS).getChar()
 		self.tradeStationText = u" %c" % self.tradeStationChar
 		
-		# store selected city as the plot
-		# a plot won't vanish and error handling on plot.isCity is easer than a dead city reference
-		self.settlementPlot = -1
-		self.WIDGET_JUMP_TO_SETTLEMENT_BUTTON = WidgetTypes.NUM_WIDGET_TYPES
-		self.JumpToSettlementButtonName = "NativeAdvisorJumpToSettlementButton"
-		
 	def getKnownSettlementList(self):
 		player = gc.getPlayer(gc.getGame().getActivePlayer())
 		knownList = []
@@ -52,27 +46,15 @@ class NativeAdvisor(BaseAdvisorWindow.BaseAdvisorWindow):
 			if bIsKnown:
 				knownList.append(pLoopCity)
 		return knownList
-		
-	def setSettlementPlot(self, iPlotID):
-		self.settlementPlot = iPlotID
-		self.drawJumpToSettlementButton()
-	
-	def drawJumpToSettlementButton(self):
-		if self.settlementPlot != -1:
-			plot = gc.getMap().plotByIndex(self.settlementPlot)
-			if plot.isCity():
-				city = plot.getPlotCity()
-				self.tableManager.getScreen().setText(self.JumpToSettlementButtonName, "Background", u"<font=4>" + localText.getText("TXT_KEY_DOMESTIC_ADVISOR_JUMP_TO_SETTLEMENT_CITY", (city.getName(), ))  + "</font>", CvUtil.FONT_LEFT_JUSTIFY, 10 + self.parent.iButtonSize, 32, 0, FontTypes.TITLE_FONT, self.WIDGET_JUMP_TO_SETTLEMENT_BUTTON, self.settlementPlot, -1)
-				return
-		# no city on plot
-		self.settlementPlot = -1
-		self.tableManager.getScreen().hide(self.JumpToSettlementButtonName)
+
+	def lookAtSettlement(self, iPlotID):
+		plot = gc.getMap().plotByIndex(iPlotID)
+		if plot is None or plot.isNone():
+			return
+		self.parent.getScreen().hideScreen()
+		CyCamera().JustLookAtPlot(plot)
 		
 	def drawTableContent(self):
-		
-			
-		self.drawJumpToSettlementButton()
-			
 		citylist = self.getKnownSettlementList()		
 		
 		self.tableManager.setNumRows(len(citylist))
@@ -124,29 +106,31 @@ class NativeAdvisor(BaseAdvisorWindow.BaseAdvisorWindow):
 	
 	def getWidgetHelp(self, argsList):
 		iScreen, eWidgetType, iData1, iData2, bOption = argsList
-		
+
 		if (eWidgetType == WidgetTypes.WIDGET_JUMP_TO_SETTLEMENT):
-			self.setSettlementPlot(iData1)
-			return ""
-			 
-		if eWidgetType == self.WIDGET_JUMP_TO_SETTLEMENT_BUTTON:
+			plot = gc.getMap().plotByIndex(iData1)
+			if plot is not None and not plot.isNone() and plot.isCity():
+				return localText.getText("TXT_KEY_DOMESTIC_ADVISOR_JUMP_TO_SETTLEMENT_CITY", (plot.getPlotCity().getName(), ))
 			return localText.getText("TXT_KEY_DOMESTIC_ADVISOR_JUMP_TO_SETTLEMENT", ())
-		
+
 		return None
 	
 	def handleInput (self, inputClass):
-	
-		if (inputClass.getNotifyCode() == NotifyCode.NOTIFY_CLICKED):
-			if (inputClass.getButtonType() == self.WIDGET_JUMP_TO_SETTLEMENT_BUTTON or inputClass.getButtonType() == WidgetTypes.WIDGET_JUMP_TO_SETTLEMENT):
-				self.parent.getScreen().hideScreen()
-				CyCamera().JustLookAtPlot(gc.getMap().plotByIndex(inputClass.getData1()))
+		if (inputClass.getNotifyCode() == NotifyCode.NOTIFY_LISTBOX_ITEM_SELECTED):
+			if (inputClass.getMouseX() == 0):
+				self.lookAtSettlement(inputClass.getData1())
 				return 0
-		
+			return -1
+
+		if (inputClass.getNotifyCode() == NotifyCode.NOTIFY_CLICKED):
+			if (inputClass.getButtonType() == WidgetTypes.WIDGET_JUMP_TO_SETTLEMENT):
+				self.lookAtSettlement(inputClass.getData1())
+				return 0
+
 		return -1
 	
 	def hide(self):
 		self.tableManager.hide()
-		self.tableManager.getScreen().hide(self.JumpToSettlementButtonName)
 		
 	def setDirty(self):
 		self.dirty = True


### PR DESCRIPTION
On the Domestic Advisor native tab, hovering a village icon updated a leftover "Jump to Pawnee" header and did not zoom. City rows already jump when you click the square on the left.

This makes native rows work the same way: click the village icon to look at that settlement. Hover help names that village. The extra header button is removed.

Python only. Restart the game.