### PR TITLE
Fix Shift-F2 Africa, chipotle city peek, and mouse-wheel to close the colony screen

### DIFF
--- a/Assets/Python/CvEventManager.py
+++ b/Assets/Python/CvEventManager.py
@@ -273,6 +273,17 @@ class CvEventManager:
 				CvScreensInterface.showAchieveAdvisorScreen()
 # Achievements END
 
+			# F2 Europe is the EXE control. Shift-F2 / Ctrl-F2 used to be eaten by
+			# the chipotle city-select cheat, so Africa never opened. Handle those
+			# chords here the same way F10 opens Achievements.
+			if (theKey == int(InputTypes.KB_F2)):
+				if self.bShift and not self.bCtrl:
+					CvScreensInterface.showAfricaScreen((-1,))
+					return 1
+				elif self.bCtrl and not self.bShift:
+					CvScreensInterface.showPortRoyalScreen((-1,))
+					return 1
+
 # TAC: EventTriggerMenu START
 # Shift+Ctrl+E im Cheatmodus
 			if( theKey == int(InputTypes.KB_E) and self.bShift and self.bCtrl and self.bAllowCheats) :
@@ -328,14 +339,6 @@ class CvEventManager:
 					if ( self.bShift ):
 						CvScreensInterface.replayScreen.showScreen(False)
 						return 1
-						
-				elif (theKey == int(InputTypes.KB_F2)):
-					if ( self.bShift ):
-						city = CyMap().plot(px, py).getPlotCity()
-						if (city != None):
-							CyInterface().selectCity(city, True)
-							return 1
-					# don't return 1 unless you want the input consumed
 
 
 		return 0

--- a/Assets/Python/CvEventManager.py
+++ b/Assets/Python/CvEventManager.py
@@ -276,8 +276,12 @@ class CvEventManager:
 			# F2 Europe is the EXE control. Shift-F2 / Ctrl-F2 used to be eaten by
 			# the chipotle city-select cheat, so Africa never opened. Handle those
 			# chords here the same way F10 opens Achievements.
+			# Chipotle peek at the hovered city is Ctrl-Shift-F2 (and map double-click).
 			if (theKey == int(InputTypes.KB_F2)):
-				if self.bShift and not self.bCtrl:
+				if self.bShift and self.bCtrl and self.bAllowCheats:
+					if self._peekCityAtPlot(px, py):
+						return 1
+				elif self.bShift and not self.bCtrl:
 					CvScreensInterface.showAfricaScreen((-1,))
 					return 1
 				elif self.bCtrl and not self.bShift:
@@ -870,6 +874,19 @@ class CvEventManager:
 		genericArgs = argsList[0][0]	# tuple of tuple of my args
 		turnSlice = genericArgs[0]
 
+	def _peekCityAtPlot(self, px, py):
+		# Chipotle: open the city under the cursor, including AI cities.
+		if px == -1 or py == -1:
+			return 0
+		plot = CyMap().plot(px, py)
+		if not plot.isCity():
+			return 0
+		city = plot.getPlotCity()
+		if city is None or city.isNone():
+			return 0
+		CyInterface().selectCity(city, True)
+		return 1
+
 	def onMouseEvent(self, argsList):
 		'mouse handler - returns 1 if the event was consumed'
 		eventType,mx,my,px,py,interfaceConsumed,screens = argsList
@@ -884,6 +901,12 @@ class CvEventManager:
 					# Launch Place Object Event
 					self.beginEvent( CvUtil.EventPlaceObject, (px, py) )
 					return 1
+
+			# EventLcButtonDblClick is sent by the EXE for map double-clicks.
+			elif ( eventType == self.EventLcButtonDblClick ):
+				if (self.bAllowCheats and not interfaceConsumed and not CyInterface().isCityScreenUp()):
+					if self._peekCityAtPlot(px, py):
+						return 1
 
 		if ( eventType == self.EventBack ):
 			return CvScreensInterface.handleBack(screens)

--- a/Assets/Python/CvEventManager.py
+++ b/Assets/Python/CvEventManager.py
@@ -366,6 +366,9 @@ class CvEventManager:
 
 		# allow camera to be updated
 		CvCameraControls.g_CameraControls.onUpdate( fDeltaTime )
+		# Wheel-click to leave the colony screen. Poll every frame; the EXE
+		# never sends a middle-button mouseEvent to Python.
+		gc.getGame().doCloseCityScreenOnMiddleMouse()
 
 	def onWindowActivation(self, argsList):
 		'Called when the game window activates or deactivates'

--- a/Assets/Python/CvEventManager.py
+++ b/Assets/Python/CvEventManager.py
@@ -874,8 +874,9 @@ class CvEventManager:
 		genericArgs = argsList[0][0]	# tuple of tuple of my args
 		turnSlice = genericArgs[0]
 
-	def _peekCityAtPlot(self, px, py):
-		# Chipotle: open the city under the cursor, including AI cities.
+	def _peekCityAtPlot(self, px, py, bOtherPlayersOnly=False):
+		# Chipotle: open the city under the cursor. Own cities already open on
+		# a normal click; intercepting those fights the EXE and closes them.
 		if px == -1 or py == -1:
 			return 0
 		plot = CyMap().plot(px, py)
@@ -883,6 +884,8 @@ class CvEventManager:
 			return 0
 		city = plot.getPlotCity()
 		if city is None or city.isNone():
+			return 0
+		if bOtherPlayersOnly and city.getOwner() == gc.getGame().getActivePlayer():
 			return 0
 		CyInterface().selectCity(city, True)
 		return 1
@@ -905,7 +908,7 @@ class CvEventManager:
 			# EventLcButtonDblClick is sent by the EXE for map double-clicks.
 			elif ( eventType == self.EventLcButtonDblClick ):
 				if (self.bAllowCheats and not interfaceConsumed and not CyInterface().isCityScreenUp()):
-					if self._peekCityAtPlot(px, py):
+					if self._peekCityAtPlot(px, py, True):
 						return 1
 
 		if ( eventType == self.EventBack ):

--- a/Assets/Python/Screens/CvMainInterface.py
+++ b/Assets/Python/Screens/CvMainInterface.py
@@ -3606,17 +3606,6 @@ class CvMainInterface:
 		global SHOW_ALL_YIELDS
 		screen = CyGInterfaceScreen("MainInterface", CvScreenEnums.MAIN_INTERFACE )
 
-		if (inputClass.getNotifyCode() == NotifyCode.NOTIFY_CLICKED) and CyInterface().isCityScreenUp():
-			iFlags = inputClass.getFlags()
-			bMiddle = False
-			if hasattr(MouseFlags, "MOUSE_MBUTTONUP") and (iFlags & MouseFlags.MOUSE_MBUTTONUP):
-				bMiddle = True
-			elif hasattr(MouseFlags, "MOUSE_MBUTTON") and (iFlags & MouseFlags.MOUSE_MBUTTON):
-				bMiddle = True
-			if bMiddle:
-				CyInterface().clearSelectedCities()
-				return 1
-
 		if (inputClass.getNotifyCode() == NotifyCode.NOTIFY_CLICKED):
 
 			if (inputClass.getButtonType() == WidgetTypes.WIDGET_GENERAL and inputClass.getData1() == BUILDING_MANAGMENT_TOGGLE):

--- a/Assets/Python/Screens/CvMainInterface.py
+++ b/Assets/Python/Screens/CvMainInterface.py
@@ -3606,6 +3606,17 @@ class CvMainInterface:
 		global SHOW_ALL_YIELDS
 		screen = CyGInterfaceScreen("MainInterface", CvScreenEnums.MAIN_INTERFACE )
 
+		if (inputClass.getNotifyCode() == NotifyCode.NOTIFY_CLICKED) and CyInterface().isCityScreenUp():
+			iFlags = inputClass.getFlags()
+			bMiddle = False
+			if hasattr(MouseFlags, "MOUSE_MBUTTONUP") and (iFlags & MouseFlags.MOUSE_MBUTTONUP):
+				bMiddle = True
+			elif hasattr(MouseFlags, "MOUSE_MBUTTON") and (iFlags & MouseFlags.MOUSE_MBUTTON):
+				bMiddle = True
+			if bMiddle:
+				CyInterface().clearSelectedCities()
+				return 1
+
 		if (inputClass.getNotifyCode() == NotifyCode.NOTIFY_CLICKED):
 
 			if (inputClass.getButtonType() == WidgetTypes.WIDGET_GENERAL and inputClass.getData1() == BUILDING_MANAGMENT_TOGGLE):

--- a/Project Files/DLLSources/CvGame.cpp
+++ b/Project Files/DLLSources/CvGame.cpp
@@ -1232,9 +1232,33 @@ int CvGame::getTeamClosenessScore(int** aaiDistances, int* aiStartingLocs)
 }
 
 
+// The EXE mouseEvent enum has no middle button, so Python never sees wheel-click.
+// Read the button ourselves while the colony screen is up.
+static void closeCityScreenOnMiddleMouse()
+{
+	static bool bWasDown = false;
+	const bool bDown = (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0;
+	const bool bClicked = bDown && !bWasDown;
+	bWasDown = bDown;
+	if (!bClicked)
+	{
+		return;
+	}
+	if (gDLL->isDiplomacy())
+	{
+		return;
+	}
+	if (!gDLL->getInterfaceIFace()->isCityScreenUp())
+	{
+		return;
+	}
+	gDLL->getInterfaceIFace()->clearSelectedCities();
+}
+
 void CvGame::update()
 {
 	MOD_PROFILE("CvGame::update");
+	closeCityScreenOnMiddleMouse();
 
 	if (!gDLL->GetWorldBuilderMode() || isInAdvancedStart())
 	{

--- a/Project Files/DLLSources/CvGame.cpp
+++ b/Project Files/DLLSources/CvGame.cpp
@@ -1232,33 +1232,9 @@ int CvGame::getTeamClosenessScore(int** aaiDistances, int* aiStartingLocs)
 }
 
 
-// The EXE mouseEvent enum has no middle button, so Python never sees wheel-click.
-// Read the button ourselves while the colony screen is up.
-static void closeCityScreenOnMiddleMouse()
-{
-	static bool bWasDown = false;
-	const bool bDown = (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0;
-	const bool bClicked = bDown && !bWasDown;
-	bWasDown = bDown;
-	if (!bClicked)
-	{
-		return;
-	}
-	if (gDLL->isDiplomacy())
-	{
-		return;
-	}
-	if (!gDLL->getInterfaceIFace()->isCityScreenUp())
-	{
-		return;
-	}
-	gDLL->getInterfaceIFace()->clearSelectedCities();
-}
-
 void CvGame::update()
 {
 	MOD_PROFILE("CvGame::update");
-	closeCityScreenOnMiddleMouse();
 
 	if (!gDLL->GetWorldBuilderMode() || isInAdvancedStart())
 	{

--- a/Project Files/DLLSources/CvGame.cpp
+++ b/Project Files/DLLSources/CvGame.cpp
@@ -1233,18 +1233,21 @@ int CvGame::getTeamClosenessScore(int** aaiDistances, int* aiStartingLocs)
 
 
 // The EXE mouseEvent enum has no middle button, so Python never sees wheel-click.
-// Read the button ourselves while the colony screen is up.
-static void closeCityScreenOnMiddleMouse()
+// Bit 0 of GetAsyncKeyState is set if the button went down since the last poll,
+// so a short click is not missed when update() skips frames.
+void CvGame::doCloseCityScreenOnMiddleMouse()
 {
 	static bool bWasDown = false;
-	const bool bDown = (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0;
-	const bool bClicked = bDown && !bWasDown;
+	const SHORT iState = GetAsyncKeyState(VK_MBUTTON);
+	const bool bDown = (iState < 0);
+	const bool bPressedSincePoll = (iState & 1) != 0;
+	const bool bClicked = bPressedSincePoll || (bDown && !bWasDown);
 	bWasDown = bDown;
 	if (!bClicked)
 	{
 		return;
 	}
-	if (gDLL->isDiplomacy())
+	if (gDLL->isDiplomacy() || gDLL->getInterfaceIFace()->isPopupUp())
 	{
 		return;
 	}
@@ -1258,7 +1261,7 @@ static void closeCityScreenOnMiddleMouse()
 void CvGame::update()
 {
 	MOD_PROFILE("CvGame::update");
-	closeCityScreenOnMiddleMouse();
+	doCloseCityScreenOnMiddleMouse();
 
 	if (!gDLL->GetWorldBuilderMode() || isInAdvancedStart())
 	{

--- a/Project Files/DLLSources/CvGame.h
+++ b/Project Files/DLLSources/CvGame.h
@@ -50,6 +50,7 @@ public:
 	void assignNativeTerritory();
 
 	DllExport void update();
+	void doCloseCityScreenOnMiddleMouse();
 	void updateScore(bool bForce = false);
 	// <advc.003y>
 	int getScoreComponent(int iRawScore, int iInitial, int iMax, int iMultiplier,

--- a/Project Files/DLLSources/CyGame.cpp
+++ b/Project Files/DLLSources/CyGame.cpp
@@ -31,6 +31,13 @@ CyGame::CyGame(CvGame* pGame) : m_pGame(pGame)
 CyGame::CyGame(CvGameAI* pGame) : m_pGame(pGame)
 {
 }
+void CyGame::doCloseCityScreenOnMiddleMouse()
+{
+	if (m_pGame)
+	{
+		pointer(CREATE_ASSERT_DATA)->doCloseCityScreenOnMiddleMouse();
+	}
+}
 void CyGame::updateScore(bool bForce)
 {
 	if (m_pGame)

--- a/Project Files/DLLSources/CyGame.h
+++ b/Project Files/DLLSources/CyGame.h
@@ -31,6 +31,7 @@ public:
 	// R&R, ray, Correct Geographical Placement of Natives - END
 
 	bool isNone() { return (m_pGame==NULL); }
+	void doCloseCityScreenOnMiddleMouse();
 	void updateScore(bool bForce);
 	void cycleCities(bool bForward, bool bAdd);
 	void cycleSelectionGroups(bool bClear, bool bForward);

--- a/Project Files/DLLSources/CyGameInterface1.cpp
+++ b/Project Files/DLLSources/CyGameInterface1.cpp
@@ -25,6 +25,7 @@ void CyGamePythonInterface1(python::class_<CyGame>& x)
 		.def("setWBCentralAmericanNative", &CyGame::setWBCentralAmericanNative)
 		// R&R, ray, Correct Geographical Placement of Natives - END
 		.def("isNone", &CyGame::isNone, "CyGame* () - is the instance valid?")
+		.def("doCloseCityScreenOnMiddleMouse", &CyGame::doCloseCityScreenOnMiddleMouse, "void ()")
 		.def("updateScore", &CyGame::updateScore, "void (bool bForce)")
 		.def("cycleCities", &CyGame::cycleCities, "void (bool bForward, bool bAdd)")
 		.def("cycleSelectionGroups", &CyGame::cycleSelectionGroups, "void (bool bClear, bool bForward)")


### PR DESCRIPTION
1. Shift-F2 is already Africa in `CIV4ControlInfos.xml`. With chipotle on, Python was stealing that key to select the city under the mouse, so Africa never opened. Shift-F2 now opens Africa, Ctrl-F2 Port Royal, F2 Europe.

2. Chipotle city peek is kept, just not on Africa's key. Double-click an AI/other-player city on the map, or Ctrl-Shift-F2 on the city under the cursor. Own cities still open on a normal click.

3. Mouse-wheel click closes the colony screen from anywhere on it. The EXE never sends a middle-button event to Python, so the DLL reads the button each frame.

4. Restart the game so both the DLL and Python load.