### PR TITLE
Pad ocean on tall maps so globe view does not go black

### DIFF
--- a/Assets/Python/pyWB/CvWBDesc.py
+++ b/Assets/Python/pyWB/CvWBDesc.py
@@ -1429,6 +1429,31 @@ class CvWBDesc:
 		print("WBSave done\n")
 		return 0	# success
 
+	def applyGlobeviewPadOffset(self):
+		iWest = CyMap().getGlobeviewPadWest()
+		iSouth = CyMap().getGlobeviewPadSouth()
+		if iWest == 0 and iSouth == 0:
+			return
+		if self.plotDesc != None:
+			for pDesc in self.plotDesc:
+				pDesc.iX = pDesc.iX + iWest
+				pDesc.iY = pDesc.iY + iSouth
+				if pDesc.cityDesc != None:
+					pDesc.cityDesc.plotX = pDesc.cityDesc.plotX + iWest
+					pDesc.cityDesc.plotY = pDesc.cityDesc.plotY + iSouth
+				for u in pDesc.unitDescs:
+					u.plotX = u.plotX + iWest
+					u.plotY = u.plotY + iSouth
+		if self.signDesc != None:
+			for pDesc in self.signDesc:
+				pDesc.iPlotX = pDesc.iPlotX + iWest
+				pDesc.iPlotY = pDesc.iPlotY + iSouth
+		if self.playersDesc != None:
+			for pWBPlayer in self.playersDesc:
+				if pWBPlayer != None and pWBPlayer.iStartingX != -1:
+					pWBPlayer.iStartingX = pWBPlayer.iStartingX + iWest
+					pWBPlayer.iStartingY = pWBPlayer.iStartingY + iSouth
+
 	def applyMap(self):
 		"after reading setup the map"
 
@@ -1439,6 +1464,10 @@ class CvWBDesc:
 		climateType = CvUtil.findInfoTypeNum(self.mapDesc.climate)
 		seaLevelType = CvUtil.findInfoTypeNum(self.mapDesc.seaLevel)
 		CyMap().rebuild(self.mapDesc.iGridW, self.mapDesc.iGridH, self.mapDesc.iTopLatitude, self.mapDesc.iBottomLatitude, self.mapDesc.bWrapX, self.mapDesc.bWrapY, WorldSizeTypes(worldSizeType), ClimateTypes(climateType), SeaLevelTypes(seaLevelType), 0, None)
+
+		# 1. globe pad splits extra ocean west/east. WB coords are the file's
+		#    original x,y so shift them onto the interior after rebuild.
+		self.applyGlobeviewPadOffset()
 
 		# update the city catchment radius
 		CyMap().setCityCatchmentRadiusNoMapMaker(self.mapDesc.iCityRadius)

--- a/Assets/XML/Misc/CIV4DetailManager.xml
+++ b/Assets/XML/Misc/CIV4DetailManager.xml
@@ -19,6 +19,8 @@
 	</Fader>
 	<Fader>
 		<Name>DF_GLOBE_TERRAIN</Name>
+		<!-- Globe texture is used at far zoom. Tall maps are padded with ocean
+		     in the DLL (issue #723 / Don_Drochilla 1.45 ratio) so this does not go black. -->
 		<Key>6000, 0.00</Key>
 		<Key>6400, 1.00</Key>
 	</Fader>
@@ -284,7 +286,7 @@
 		<Key>7619,26</Key>
 		<Key>9908,30</Key>
 		<Key>19799,30</Key>
-		<Key>100000,90</Key>
+		<Key>100000,30</Key>
 	</Fader>
 	<Fader>
 		<Name>GLOBE_SPOTLIGHT_XTRANS</Name>

--- a/Project Files/DLLSources/CvCitySavegame.cpp
+++ b/Project Files/DLLSources/CvCitySavegame.cpp
@@ -595,6 +595,9 @@ void CvCity::read(CvSavegameReader reader)
 		}
 	}
 
+	GC.getMap().offsetGlobeviewCoordinates(m_coord);
+	GC.getMap().offsetGlobeviewCoordinates(m_rallyCoordinates);
+
 	// BUG WORKAROUND. Reset any yield, which stores negative amount
 	// ideally this shouldn't be here, but it makes the asserts and error message
 	// trigger when the bug triggers again rather than triggering if the bug happened prior to saving

--- a/Project Files/DLLSources/CvMap.cpp
+++ b/Project Files/DLLSources/CvMap.cpp
@@ -342,13 +342,17 @@ void CvMap::reset(CvMapInitData* pInitInfo)
 
 // 1. EXE globe texture goes black on tall maps (Americas Gigantic 136x256).
 //    Issue #723 and Don_Drochilla: keep height/width around 1.45 at gigantic Y
-//    (1.72 on huge). Pad ocean on the east/south on new games AND on save load
-//    so the user does not have to edit the map file. Existing x,y stay valid.
-//    Extra ocean copies Europe from the old edge and joins the biggest water area.
+//    (1.72 on huge). Pad ocean on new games AND on save load so the user does
+//    not have to edit the map file.
+// 2. Split the extra columns on west AND east (rows on south AND north).
+//    East-only pad made east-coast starts sail farther to Europe.
+//    Unpadded saves shift plot/city/unit x,y by the west/south amount.
 void CvMap::applyGlobeviewSafeDimensions()
 {
 	m_iGlobeviewPadX = 0;
 	m_iGlobeviewPadY = 0;
+	m_iGlobeviewPadWest = 0;
+	m_iGlobeviewPadSouth = 0;
 
 	if (m_iGridWidth <= 0 || m_iGridHeight <= 0)
 	{
@@ -373,14 +377,80 @@ void CvMap::applyGlobeviewSafeDimensions()
 		if (m_iGridWidth < iNeededShort)
 		{
 			m_iGlobeviewPadX = iNeededShort - m_iGridWidth;
+			m_iGlobeviewPadWest = m_iGlobeviewPadX / 2;
 			m_iGridWidth = iNeededShort;
 		}
 	}
 	else if (m_iGridHeight < iNeededShort)
 	{
 		m_iGlobeviewPadY = iNeededShort - m_iGridHeight;
+		m_iGlobeviewPadSouth = m_iGlobeviewPadY / 2;
 		m_iGridHeight = iNeededShort;
 	}
+}
+
+int CvMap::getGlobeviewPadWest() const
+{
+	return m_iGlobeviewPadWest;
+}
+
+int CvMap::getGlobeviewPadSouth() const
+{
+	return m_iGlobeviewPadSouth;
+}
+
+void CvMap::offsetGlobeviewCoordinates(int& iX, int& iY) const
+{
+	if (m_iGlobeviewPadWest == 0 && m_iGlobeviewPadSouth == 0)
+	{
+		return;
+	}
+	if (iX == INVALID_PLOT_COORD || iY == INVALID_PLOT_COORD)
+	{
+		return;
+	}
+	if (iX < 0 || iY < 0)
+	{
+		return;
+	}
+	iX += m_iGlobeviewPadWest;
+	iY += m_iGlobeviewPadSouth;
+}
+
+void CvMap::offsetGlobeviewCoordinates(Coordinates& coord) const
+{
+	if (m_iGlobeviewPadWest == 0 && m_iGlobeviewPadSouth == 0)
+	{
+		return;
+	}
+	if (coord.isInvalidPlotCoord())
+	{
+		return;
+	}
+	int iX = coord.x();
+	int iY = coord.y();
+	offsetGlobeviewCoordinates(iX, iY);
+	coord.set(iX, iY);
+}
+
+bool CvMap::isGlobeviewPadPlot(int iX, int iY) const
+{
+	if (m_iGlobeviewPadX <= 0 && m_iGlobeviewPadY <= 0)
+	{
+		return false;
+	}
+
+	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
+	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
+	if (iX < m_iGlobeviewPadWest || iX >= m_iGlobeviewPadWest + iOrigWidth)
+	{
+		return true;
+	}
+	if (iY < m_iGlobeviewPadSouth || iY >= m_iGlobeviewPadSouth + iOrigHeight)
+	{
+		return true;
+	}
+	return false;
 }
 
 void CvMap::applyGlobeviewPadPlotDefaults()
@@ -390,14 +460,11 @@ void CvMap::applyGlobeviewPadPlotDefaults()
 		return;
 	}
 
-	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
-	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
-
 	for (int iX = 0; iX < getGridWidthINLINE(); iX++)
 	{
 		for (int iY = 0; iY < getGridHeightINLINE(); iY++)
 		{
-			if (iX >= iOrigWidth || iY >= iOrigHeight)
+			if (isGlobeviewPadPlot(iX, iY))
 			{
 				CvPlot* pPlot = plotSoren(iX, iY);
 				pPlot->init(iX, iY);
@@ -416,12 +483,16 @@ void CvMap::applyGlobeviewPadEurope()
 
 	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
 	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
+	const int iWestEdge = m_iGlobeviewPadWest;
+	const int iEastEdge = m_iGlobeviewPadWest + iOrigWidth - 1;
+	const int iSouthEdge = m_iGlobeviewPadSouth;
+	const int iNorthEdge = m_iGlobeviewPadSouth + iOrigHeight - 1;
 
 	for (int iX = 0; iX < getGridWidthINLINE(); iX++)
 	{
 		for (int iY = 0; iY < getGridHeightINLINE(); iY++)
 		{
-			if (iX < iOrigWidth && iY < iOrigHeight)
+			if (!isGlobeviewPadPlot(iX, iY))
 			{
 				continue;
 			}
@@ -433,13 +504,21 @@ void CvMap::applyGlobeviewPadEurope()
 			}
 
 			EuropeTypes eEurope = NO_EUROPE;
-			if (iX >= iOrigWidth && iOrigWidth > 0)
+			if (iX < iWestEdge && iOrigWidth > 0)
 			{
-				eEurope = plotSoren(iOrigWidth - 1, iY)->getEurope();
+				eEurope = plotSoren(iWestEdge, iY)->getEurope();
 			}
-			if (eEurope == NO_EUROPE && iY >= iOrigHeight && iOrigHeight > 0)
+			else if (iX > iEastEdge && iOrigWidth > 0)
 			{
-				eEurope = plotSoren(iX, iOrigHeight - 1)->getEurope();
+				eEurope = plotSoren(iEastEdge, iY)->getEurope();
+			}
+			if (eEurope == NO_EUROPE && iY < iSouthEdge && iOrigHeight > 0)
+			{
+				eEurope = plotSoren(iX, iSouthEdge)->getEurope();
+			}
+			if (eEurope == NO_EUROPE && iY > iNorthEdge && iOrigHeight > 0)
+			{
+				eEurope = plotSoren(iX, iNorthEdge)->getEurope();
 			}
 			if (eEurope != NO_EUROPE)
 			{
@@ -463,14 +542,12 @@ void CvMap::applyGlobeviewPadAreas()
 	}
 
 	const int iArea = pWaterArea->getID();
-	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
-	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
 
 	for (int iX = 0; iX < getGridWidthINLINE(); iX++)
 	{
 		for (int iY = 0; iY < getGridHeightINLINE(); iY++)
 		{
-			if (iX < iOrigWidth && iY < iOrigHeight)
+			if (!isGlobeviewPadPlot(iX, iY))
 			{
 				continue;
 			}

--- a/Project Files/DLLSources/CvMap.cpp
+++ b/Project Files/DLLSources/CvMap.cpp
@@ -227,6 +227,10 @@ void CvMap::init(CvMapInitData* pInitInfo/*=NULL*/)
 	//--------------------------------
 	// Init saved data
 	reset(pInitInfo);
+	// 1. pad here, not in reset(). reset() also runs on save load (0x0 then the
+	//    save's own width). padding inside reset() grew a 136x256 save during load
+	//    and the EXE aborted. new games / WB come through init() so they still pad.
+	applyGlobeviewSafeDimensions();
 
 	//--------------------------------
 	// Init containers
@@ -335,15 +339,13 @@ void CvMap::reset(CvMapInitData* pInitInfo)
 		gDLL->getPythonIFace()->pythonGetWrapXY(&m_bWrapX, &m_bWrapY);
 	}
 
-	applyGlobeviewSafeDimensions();
-
 	m_areas.removeAll();
 }
 
 // 1. EXE globe texture goes black on tall maps (Americas Gigantic 136x256).
 //    Issue #723 and Don_Drochilla: keep height/width around 1.45 at gigantic Y
 //    (1.72 on huge). Pad ocean on NEW games / WB. Do not grow the plot array
-//    while reading a save: We-The-People 136x256 saves (Tish) abort the EXE.
+//    while reading a save: We-The-People 136x256 saves abort the EXE.
 // 2. Split the extra columns on west AND east (rows on south AND north).
 //    East-only pad made east-coast starts sail farther to Europe.
 //    Unpadded saves shift plot/city/unit x,y by the west/south amount.

--- a/Project Files/DLLSources/CvMap.cpp
+++ b/Project Files/DLLSources/CvMap.cpp
@@ -399,6 +399,39 @@ int CvMap::getGlobeviewPadSouth() const
 	return m_iGlobeviewPadSouth;
 }
 
+bool CvMap::hasGlobeviewOriginOffset() const
+{
+	return (m_iGlobeviewPadWest != 0 || m_iGlobeviewPadSouth != 0);
+}
+
+int CvMap::remapGlobeviewSavedPlotIndex(int iOldPlot) const
+{
+	if (iOldPlot < 0)
+	{
+		return iOldPlot;
+	}
+	if (m_iGlobeviewPadWest == 0 && m_iGlobeviewPadSouth == 0)
+	{
+		return iOldPlot;
+	}
+
+	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
+	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
+	if (iOrigWidth <= 0)
+	{
+		return -1;
+	}
+
+	const int iX = iOldPlot % iOrigWidth;
+	const int iY = iOldPlot / iOrigWidth;
+	if (iX < 0 || iX >= iOrigWidth || iY < 0 || iY >= iOrigHeight)
+	{
+		return -1;
+	}
+
+	return plotNumINLINE(iX + m_iGlobeviewPadWest, iY + m_iGlobeviewPadSouth);
+}
+
 void CvMap::offsetGlobeviewCoordinates(int& iX, int& iY) const
 {
 	if (m_iGlobeviewPadWest == 0 && m_iGlobeviewPadSouth == 0)

--- a/Project Files/DLLSources/CvMap.cpp
+++ b/Project Files/DLLSources/CvMap.cpp
@@ -249,6 +249,7 @@ void CvMap::init(CvMapInitData* pInitInfo/*=NULL*/)
 			kPlot.init(iX, iY);
 		}
 	}
+	applyGlobeviewPadPlotDefaults();
 	calculateAreas();
 	gDLL->logMemState("CvMap after init plots");
 }
@@ -334,7 +335,116 @@ void CvMap::reset(CvMapInitData* pInitInfo)
 		gDLL->getPythonIFace()->pythonGetWrapXY(&m_bWrapX, &m_bWrapY);
 	}
 
+	applyGlobeviewSafeDimensions();
+
 	m_areas.removeAll();
+}
+
+// 1. EXE globe texture goes black on tall maps (Americas Gigantic 136x256).
+//    Issue #723 and Don_Drochilla: keep height/width around 1.45 at gigantic Y
+//    (1.72 on huge). Pad ocean on the east/south so the user does not have to
+//    edit the map file. Existing x,y stay valid. Europe tiles stay where WB
+//    put them; extra ocean copies that Europe type after the map is filled.
+void CvMap::applyGlobeviewSafeDimensions()
+{
+	m_iGlobeviewPadX = 0;
+	m_iGlobeviewPadY = 0;
+
+	if (m_iGridWidth <= 0 || m_iGridHeight <= 0)
+	{
+		return;
+	}
+
+	const int iLong = std::max(m_iGridWidth, m_iGridHeight);
+	int iSafeRatio100 = 145;
+	if (iLong <= 100)
+	{
+		iSafeRatio100 = 172;
+	}
+	else if (iLong < 184)
+	{
+		iSafeRatio100 = 172 + (iLong - 100) * (145 - 172) / (184 - 100);
+	}
+
+	const int iNeededShort = (iLong * 100 + iSafeRatio100 - 1) / iSafeRatio100;
+
+	if (m_iGridHeight >= m_iGridWidth)
+	{
+		if (m_iGridWidth < iNeededShort)
+		{
+			m_iGlobeviewPadX = iNeededShort - m_iGridWidth;
+			m_iGridWidth = iNeededShort;
+		}
+	}
+	else if (m_iGridHeight < iNeededShort)
+	{
+		m_iGlobeviewPadY = iNeededShort - m_iGridHeight;
+		m_iGridHeight = iNeededShort;
+	}
+}
+
+void CvMap::applyGlobeviewPadPlotDefaults()
+{
+	if (m_pMapPlots == NULL || (m_iGlobeviewPadX <= 0 && m_iGlobeviewPadY <= 0))
+	{
+		return;
+	}
+
+	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
+	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
+
+	for (int iX = 0; iX < getGridWidthINLINE(); iX++)
+	{
+		for (int iY = 0; iY < getGridHeightINLINE(); iY++)
+		{
+			if (iX >= iOrigWidth || iY >= iOrigHeight)
+			{
+				plotSoren(iX, iY)->setTerrainType(TERRAIN_OCEAN, false, false);
+			}
+		}
+	}
+}
+
+void CvMap::applyGlobeviewPadEurope()
+{
+	if (m_pMapPlots == NULL || (m_iGlobeviewPadX <= 0 && m_iGlobeviewPadY <= 0))
+	{
+		return;
+	}
+
+	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
+	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
+
+	for (int iX = 0; iX < getGridWidthINLINE(); iX++)
+	{
+		for (int iY = 0; iY < getGridHeightINLINE(); iY++)
+		{
+			if (iX < iOrigWidth && iY < iOrigHeight)
+			{
+				continue;
+			}
+
+			CvPlot* pPlot = plotSoren(iX, iY);
+			if (pPlot == NULL || !pPlot->isWater() || pPlot->getEurope() != NO_EUROPE)
+			{
+				continue;
+			}
+
+			EuropeTypes eEurope = NO_EUROPE;
+			if (iX >= iOrigWidth && iOrigWidth > 0)
+			{
+				eEurope = plotSoren(iOrigWidth - 1, iY)->getEurope();
+			}
+			if (eEurope == NO_EUROPE && iY >= iOrigHeight && iOrigHeight > 0)
+			{
+				eEurope = plotSoren(iX, iOrigHeight - 1)->getEurope();
+			}
+			if (eEurope != NO_EUROPE)
+			{
+				pPlot->setEurope(eEurope);
+			}
+		}
+	}
 }
 
 
@@ -1375,6 +1485,8 @@ void CvMap::updateWaterPlotTerrainTypes()
 			}
 		}
 	}
+
+	applyGlobeviewPadEurope();
 }
 // autodetect lakes - end
 

--- a/Project Files/DLLSources/CvMap.cpp
+++ b/Project Files/DLLSources/CvMap.cpp
@@ -342,8 +342,8 @@ void CvMap::reset(CvMapInitData* pInitInfo)
 
 // 1. EXE globe texture goes black on tall maps (Americas Gigantic 136x256).
 //    Issue #723 and Don_Drochilla: keep height/width around 1.45 at gigantic Y
-//    (1.72 on huge). Pad ocean on new games AND on save load so the user does
-//    not have to edit the map file.
+//    (1.72 on huge). Pad ocean on NEW games / WB. Do not grow the plot array
+//    while reading a save: We-The-People 136x256 saves (Tish) abort the EXE.
 // 2. Split the extra columns on west AND east (rows on south AND north).
 //    East-only pad made east-coast starts sail farther to Europe.
 //    Unpadded saves shift plot/city/unit x,y by the west/south amount.

--- a/Project Files/DLLSources/CvMap.cpp
+++ b/Project Files/DLLSources/CvMap.cpp
@@ -342,9 +342,9 @@ void CvMap::reset(CvMapInitData* pInitInfo)
 
 // 1. EXE globe texture goes black on tall maps (Americas Gigantic 136x256).
 //    Issue #723 and Don_Drochilla: keep height/width around 1.45 at gigantic Y
-//    (1.72 on huge). Pad ocean on the east/south so the user does not have to
-//    edit the map file. Existing x,y stay valid. Europe tiles stay where WB
-//    put them; extra ocean copies that Europe type after the map is filled.
+//    (1.72 on huge). Pad ocean on the east/south on new games AND on save load
+//    so the user does not have to edit the map file. Existing x,y stay valid.
+//    Extra ocean copies Europe from the old edge and joins the biggest water area.
 void CvMap::applyGlobeviewSafeDimensions()
 {
 	m_iGlobeviewPadX = 0;
@@ -399,7 +399,9 @@ void CvMap::applyGlobeviewPadPlotDefaults()
 		{
 			if (iX >= iOrigWidth || iY >= iOrigHeight)
 			{
-				plotSoren(iX, iY)->setTerrainType(TERRAIN_OCEAN, false, false);
+				CvPlot* pPlot = plotSoren(iX, iY);
+				pPlot->init(iX, iY);
+				pPlot->setTerrainType(TERRAIN_OCEAN, false, false);
 			}
 		}
 	}
@@ -442,6 +444,41 @@ void CvMap::applyGlobeviewPadEurope()
 			if (eEurope != NO_EUROPE)
 			{
 				pPlot->setEurope(eEurope);
+			}
+		}
+	}
+}
+
+void CvMap::applyGlobeviewPadAreas()
+{
+	if (m_pMapPlots == NULL || (m_iGlobeviewPadX <= 0 && m_iGlobeviewPadY <= 0))
+	{
+		return;
+	}
+
+	CvArea* pWaterArea = findBiggestArea(true);
+	if (pWaterArea == NULL)
+	{
+		return;
+	}
+
+	const int iArea = pWaterArea->getID();
+	const int iOrigWidth = getGridWidthINLINE() - m_iGlobeviewPadX;
+	const int iOrigHeight = getGridHeightINLINE() - m_iGlobeviewPadY;
+
+	for (int iX = 0; iX < getGridWidthINLINE(); iX++)
+	{
+		for (int iY = 0; iY < getGridHeightINLINE(); iY++)
+		{
+			if (iX < iOrigWidth && iY < iOrigHeight)
+			{
+				continue;
+			}
+
+			CvPlot* pPlot = plotSoren(iX, iY);
+			if (pPlot != NULL && pPlot->isWater())
+			{
+				pPlot->setArea(iArea);
 			}
 		}
 	}

--- a/Project Files/DLLSources/CvMap.cpp
+++ b/Project Files/DLLSources/CvMap.cpp
@@ -500,7 +500,7 @@ void CvMap::applyGlobeviewPadPlotDefaults()
 			if (isGlobeviewPadPlot(iX, iY))
 			{
 				CvPlot* pPlot = plotSoren(iX, iY);
-				pPlot->init(iX, iY);
+				// already init'd on load/new map. do not init again (uninit+gDLL destroy).
 				pPlot->setTerrainType(TERRAIN_OCEAN, false, false);
 			}
 		}

--- a/Project Files/DLLSources/CvMap.h
+++ b/Project Files/DLLSources/CvMap.h
@@ -122,6 +122,7 @@ protected:
 	void applyGlobeviewPadPlotDefaults();
 	void applyGlobeviewPadEurope();
 	void applyGlobeviewPadAreas();
+	bool isGlobeviewPadPlot(int iX, int iY) const;
 
 public:
 	DllExport void erasePlots();
@@ -208,6 +209,11 @@ public:
 	{
 		return m_iGridHeight;
 	}
+
+	int getGlobeviewPadWest() const;
+	int getGlobeviewPadSouth() const;
+	void offsetGlobeviewCoordinates(int& iX, int& iY) const;
+	void offsetGlobeviewCoordinates(Coordinates& coord) const;
 
 	int getLandPlots() const;
 	void changeLandPlots(int iChange);
@@ -357,6 +363,8 @@ protected:
 	int m_iNextRiverID;
 	int m_iGlobeviewPadX;
 	int m_iGlobeviewPadY;
+	int m_iGlobeviewPadWest;
+	int m_iGlobeviewPadSouth;
 
 	bool m_bWrapX;	
 	bool m_bWrapY;

--- a/Project Files/DLLSources/CvMap.h
+++ b/Project Files/DLLSources/CvMap.h
@@ -118,6 +118,9 @@ protected:
 
 	void uninit();
 	void setup();
+	void applyGlobeviewSafeDimensions();
+	void applyGlobeviewPadPlotDefaults();
+	void applyGlobeviewPadEurope();
 
 public:
 	DllExport void erasePlots();
@@ -351,6 +354,8 @@ protected:
 	int m_iTopLatitude;
 	int m_iBottomLatitude;
 	int m_iNextRiverID;
+	int m_iGlobeviewPadX;
+	int m_iGlobeviewPadY;
 
 	bool m_bWrapX;	
 	bool m_bWrapY;

--- a/Project Files/DLLSources/CvMap.h
+++ b/Project Files/DLLSources/CvMap.h
@@ -121,6 +121,7 @@ protected:
 	void applyGlobeviewSafeDimensions();
 	void applyGlobeviewPadPlotDefaults();
 	void applyGlobeviewPadEurope();
+	void applyGlobeviewPadAreas();
 
 public:
 	DllExport void erasePlots();

--- a/Project Files/DLLSources/CvMap.h
+++ b/Project Files/DLLSources/CvMap.h
@@ -212,8 +212,10 @@ public:
 
 	int getGlobeviewPadWest() const;
 	int getGlobeviewPadSouth() const;
+	bool hasGlobeviewOriginOffset() const;
 	void offsetGlobeviewCoordinates(int& iX, int& iY) const;
 	void offsetGlobeviewCoordinates(Coordinates& coord) const;
+	int remapGlobeviewSavedPlotIndex(int iOldPlot) const;
 
 	int getLandPlots() const;
 	void changeLandPlots(int iChange);

--- a/Project Files/DLLSources/CvMapSavegame.cpp
+++ b/Project Files/DLLSources/CvMapSavegame.cpp
@@ -152,7 +152,9 @@ void CvMap::read(CvSavegameReader reader)
 					pPlot->setCoordinates(iX + iWest, iY + iSouth);
 				}
 			}
-			applyGlobeviewPadPlotDefaults();
+			// 1. do not setTerrainType on pad plots here. areas are not in the save yet
+			//    (Plots is written before Areas). Tish / We-The-People gigantic saves
+			//    aborted in the EXE when ocean pad ran during plot read.
 			break;
 		}
 		case Save_Areas:
@@ -181,6 +183,10 @@ void CvMap::read(CvSavegameReader reader)
 			if (eBonus != NO_BONUS || eImprovement != NO_IMPROVEMENT)
 			{
 				CvArea* pArea = getArea(kPlot.getArea());
+				if (pArea == NULL)
+				{
+					continue;
+				}
 				if (eBonus != NO_BONUS)
 				{
 					pArea->changeNumBonuses(eBonus, 1);
@@ -198,6 +204,7 @@ void CvMap::read(CvSavegameReader reader)
 		}
 	}
 
+	applyGlobeviewPadPlotDefaults();
 	applyGlobeviewPadAreas();
 	applyGlobeviewPadEurope();
 }

--- a/Project Files/DLLSources/CvMapSavegame.cpp
+++ b/Project Files/DLLSources/CvMapSavegame.cpp
@@ -73,6 +73,8 @@ void CvMap::resetSavedData()
 	m_iNextRiverID      = defaultNextRiverID;
 	m_iGlobeviewPadX    = 0;
 	m_iGlobeviewPadY    = 0;
+	m_iGlobeviewPadWest = 0;
+	m_iGlobeviewPadSouth = 0;
 	m_bWrapX            = defaultWrapX;
 	m_bWrapY            = defaultWrapY;
 	m_bHasStream		= defaultHasStream;
@@ -132,11 +134,22 @@ void CvMap::read(CvSavegameReader reader)
 			const int iSavedHeight = m_iGridHeight;
 			applyGlobeviewSafeDimensions();
 			m_pMapPlots = new CvPlot[numPlotsINLINE()];
+			for (int iY = 0; iY < getGridHeightINLINE(); ++iY)
+			{
+				for (int iX = 0; iX < getGridWidthINLINE(); ++iX)
+				{
+					plotSoren(iX, iY)->init(iX, iY);
+				}
+			}
+			const int iWest = m_iGlobeviewPadWest;
+			const int iSouth = m_iGlobeviewPadSouth;
 			for (int iY = 0; iY < iSavedHeight; ++iY)
 			{
 				for (int iX = 0; iX < iSavedWidth; ++iX)
 				{
-					plotSoren(iX, iY)->read(reader);
+					CvPlot* pPlot = plotSoren(iX + iWest, iY + iSouth);
+					pPlot->read(reader);
+					pPlot->setCoordinates(iX + iWest, iY + iSouth);
 				}
 			}
 			applyGlobeviewPadPlotDefaults();

--- a/Project Files/DLLSources/CvMapSavegame.cpp
+++ b/Project Files/DLLSources/CvMapSavegame.cpp
@@ -130,8 +130,8 @@ void CvMap::read(CvSavegameReader reader)
 		case Save_Plots:
 		{
 			FAssertMsg(m_pMapPlots == NULL, "Memory leak");
-			// 1. do not applyGlobeviewSafeDimensions here. Tish (We-The-People Americas
-			//    Gigantic 136x256) aborts the EXE if we grow the plot array during load.
+			// 1. do not applyGlobeviewSafeDimensions here. We-The-People Americas
+			//    Gigantic 136x256 saves abort the EXE if we grow the plot array during load.
 			//    pad only on new games (CvMap::init). already-padded 177-wide saves load as-is.
 			const int iNumPlots = numPlotsINLINE();
 			m_pMapPlots = new CvPlot[iNumPlots];

--- a/Project Files/DLLSources/CvMapSavegame.cpp
+++ b/Project Files/DLLSources/CvMapSavegame.cpp
@@ -71,6 +71,8 @@ void CvMap::resetSavedData()
 	m_iTopLatitude      = defaultTopLatitude;
 	m_iBottomLatitude   = defaultBottomLatitude;
 	m_iNextRiverID      = defaultNextRiverID;
+	m_iGlobeviewPadX    = 0;
+	m_iGlobeviewPadY    = 0;
 	m_bWrapX            = defaultWrapX;
 	m_bWrapY            = defaultWrapY;
 	m_bHasStream		= defaultHasStream;

--- a/Project Files/DLLSources/CvMapSavegame.cpp
+++ b/Project Files/DLLSources/CvMapSavegame.cpp
@@ -130,31 +130,15 @@ void CvMap::read(CvSavegameReader reader)
 		case Save_Plots:
 		{
 			FAssertMsg(m_pMapPlots == NULL, "Memory leak");
-			const int iSavedWidth = m_iGridWidth;
-			const int iSavedHeight = m_iGridHeight;
-			applyGlobeviewSafeDimensions();
-			m_pMapPlots = new CvPlot[numPlotsINLINE()];
-			for (int iY = 0; iY < getGridHeightINLINE(); ++iY)
+			// 1. do not applyGlobeviewSafeDimensions here. Tish (We-The-People Americas
+			//    Gigantic 136x256) aborts the EXE if we grow the plot array during load.
+			//    pad only on new games (CvMap::init). already-padded 177-wide saves load as-is.
+			const int iNumPlots = numPlotsINLINE();
+			m_pMapPlots = new CvPlot[iNumPlots];
+			for (int iI = 0; iI < iNumPlots; ++iI)
 			{
-				for (int iX = 0; iX < getGridWidthINLINE(); ++iX)
-				{
-					plotSoren(iX, iY)->init(iX, iY);
-				}
+				m_pMapPlots[iI].read(reader);
 			}
-			const int iWest = m_iGlobeviewPadWest;
-			const int iSouth = m_iGlobeviewPadSouth;
-			for (int iY = 0; iY < iSavedHeight; ++iY)
-			{
-				for (int iX = 0; iX < iSavedWidth; ++iX)
-				{
-					CvPlot* pPlot = plotSoren(iX + iWest, iY + iSouth);
-					pPlot->read(reader);
-					pPlot->setCoordinates(iX + iWest, iY + iSouth);
-				}
-			}
-			// 1. do not setTerrainType on pad plots here. areas are not in the save yet
-			//    (Plots is written before Areas). Tish / We-The-People gigantic saves
-			//    aborted in the EXE when ocean pad ran during plot read.
 			break;
 		}
 		case Save_Areas:
@@ -203,10 +187,6 @@ void CvMap::read(CvSavegameReader reader)
 			}
 		}
 	}
-
-	applyGlobeviewPadPlotDefaults();
-	applyGlobeviewPadAreas();
-	applyGlobeviewPadEurope();
 }
 
 void CvMap::write(CvSavegameWriter writer)

--- a/Project Files/DLLSources/CvMapSavegame.cpp
+++ b/Project Files/DLLSources/CvMapSavegame.cpp
@@ -128,12 +128,18 @@ void CvMap::read(CvSavegameReader reader)
 		case Save_Plots:
 		{
 			FAssertMsg(m_pMapPlots == NULL, "Memory leak");
-			const int iNumPlots = numPlotsINLINE();
-			m_pMapPlots = new CvPlot[iNumPlots];
-			for (int iI = 0; iI < iNumPlots; ++iI)
+			const int iSavedWidth = m_iGridWidth;
+			const int iSavedHeight = m_iGridHeight;
+			applyGlobeviewSafeDimensions();
+			m_pMapPlots = new CvPlot[numPlotsINLINE()];
+			for (int iY = 0; iY < iSavedHeight; ++iY)
 			{
-				m_pMapPlots[iI].read(reader);
+				for (int iX = 0; iX < iSavedWidth; ++iX)
+				{
+					plotSoren(iX, iY)->read(reader);
+				}
 			}
+			applyGlobeviewPadPlotDefaults();
 			break;
 		}
 		case Save_Areas:
@@ -178,6 +184,9 @@ void CvMap::read(CvSavegameReader reader)
 			}
 		}
 	}
+
+	applyGlobeviewPadAreas();
+	applyGlobeviewPadEurope();
 }
 
 void CvMap::write(CvSavegameWriter writer)

--- a/Project Files/DLLSources/CvPlayerAISavegame.cpp
+++ b/Project Files/DLLSources/CvPlayerAISavegame.cpp
@@ -290,9 +290,21 @@ void CvPlayerAI::read(CvSavegameReader reader)
 		case PlayerSaveAI_StrategyData: reader.Read(m_em_iStrategyData); break;
 		}
 	}
-	
-	// Loading done. Set up the cache (if any).
 
+	if (GC.getMap().hasGlobeviewOriginOffset())
+	{
+		AI_invalidateDistanceMap();
+		m_distanceMap.clear();
+		for (YieldTypes eYield = FIRST_YIELD; eYield < NUM_YIELD_TYPES; ++eYield)
+		{
+			m_em_iBestWorkedYieldPlots.set(eYield, GC.getMap().remapGlobeviewSavedPlotIndex(m_em_iBestWorkedYieldPlots.get(eYield)));
+			m_em_iBestUnworkedYieldPlots.set(eYield, GC.getMap().remapGlobeviewSavedPlotIndex(m_em_iBestUnworkedYieldPlots.get(eYield)));
+		}
+		for (unsigned int i = 0; i < m_aiAICitySites.size(); ++i)
+		{
+			m_aiAICitySites[i] = GC.getMap().remapGlobeviewSavedPlotIndex(m_aiAICitySites[i]);
+		}
+	}
 }
 
 void CvPlayerAI::write(CvSavegameWriter writer)

--- a/Project Files/DLLSources/CvPlayerSavegame.cpp
+++ b/Project Files/DLLSources/CvPlayerSavegame.cpp
@@ -1014,6 +1014,8 @@ void CvPlayer::read(CvSavegameReader reader)
 		}
 	}
 
+	GC.getMap().offsetGlobeviewCoordinates(m_iStartingX, m_iStartingY);
+
 	// remove NO_UNIT from revolutionary units
 	// They are no longer possible to add, but savegames might still hold on to them
 	for (unsigned int i = 0; i < m_aEuropeRevolutionUnits.size();)

--- a/Project Files/DLLSources/CvPlot.h
+++ b/Project Files/DLLSources/CvPlot.h
@@ -274,6 +274,10 @@ public:
 	{
 		return m_coord;
 	}
+	void setCoordinates(int iX, int iY)
+	{
+		m_coord.set(iX, iY);
+	}
 	bool at(int iX, int iY) const;
 	bool at(Coordinates coord) const;
 	int getIndex() const;

--- a/Project Files/DLLSources/CvSelectionGroupAISavegame.cpp
+++ b/Project Files/DLLSources/CvSelectionGroupAISavegame.cpp
@@ -95,7 +95,9 @@ void CvSelectionGroupAI::read(CvSavegameReader reader)
 		case SelectionGroupAISave_GroupAttackY: reader.Read(m_iGroupAttackY); break;
 		}
 	}
-	
+
+	GC.getMap().offsetGlobeviewCoordinates(m_iMissionAIX, m_iMissionAIY);
+	GC.getMap().offsetGlobeviewCoordinates(m_iGroupAttackX, m_iGroupAttackY);
 }
 
 void CvSelectionGroupAI::write(CvSavegameWriter writer)

--- a/Project Files/DLLSources/CvSelectionGroupSavegame.cpp
+++ b/Project Files/DLLSources/CvSelectionGroupSavegame.cpp
@@ -105,7 +105,21 @@ void CvSelectionGroup::read(CvSavegameReader reader)
 			break;
 		}
 	}
-	
+
+	if (GC.getMap().getGlobeviewPadWest() != 0 || GC.getMap().getGlobeviewPadSouth() != 0)
+	{
+		for (CLLNode<MissionData>* pMissionNode = headMissionQueueNode(); pMissionNode != NULL; pMissionNode = nextMissionQueueNode(pMissionNode))
+		{
+			MissionData& kMission = pMissionNode->m_data;
+			if (kMission.eMissionType == MISSION_MOVE_TO ||
+				kMission.eMissionType == MISSION_ROUTE_TO ||
+				kMission.eMissionType == MISSION_ROUTE_TO_ROAD ||
+				kMission.eMissionType == MISSION_ROUTE_TO_COUNTRY_ROAD)
+			{
+				GC.getMap().offsetGlobeviewCoordinates(kMission.iData1, kMission.iData2);
+			}
+		}
+	}
 }
 
 void CvSelectionGroup::write(CvSavegameWriter writer)

--- a/Project Files/DLLSources/CvStructs.cpp
+++ b/Project Files/DLLSources/CvStructs.cpp
@@ -233,6 +233,7 @@ void PlotExtraYield::read(CvSavegameReader& reader)
 {
 	reader.Read(m_iX);
 	reader.Read(m_iY);
+	GC.getMap().offsetGlobeviewCoordinates(m_iX, m_iY);
 
 	// use savegame code in EnumMap to allow for xml changes in yield xml
 	EnumMap<YieldTypes, int> tempArray;

--- a/Project Files/DLLSources/CvUnitSavegame.cpp
+++ b/Project Files/DLLSources/CvUnitSavegame.cpp
@@ -372,6 +372,9 @@ void CvUnit::read(CvSavegameReader reader)
 		}
 	}
 
+	GC.getMap().offsetGlobeviewCoordinates(m_coord);
+	GC.getMap().offsetGlobeviewCoordinates(m_iAttackPlotX, m_iAttackPlotY);
+
 	// The unit is loaded. Now set up the cache according to the read data.
 
 	FAssert(NO_UNIT != m_eUnitType);

--- a/Project Files/DLLSources/CyMap.cpp
+++ b/Project Files/DLLSources/CyMap.cpp
@@ -121,6 +121,16 @@ int CyMap::getGridHeight()
 	return m_pMap->getGridHeightINLINE();
 }
 
+int CyMap::getGlobeviewPadWest()
+{
+	return m_pMap ? m_pMap->getGlobeviewPadWest() : 0;
+}
+
+int CyMap::getGlobeviewPadSouth()
+{
+	return m_pMap ? m_pMap->getGlobeviewPadSouth() : 0;
+}
+
 int CyMap::getLandPlots()
 {
 	return m_pMap ? m_pMap->getLandPlots() : -1;

--- a/Project Files/DLLSources/CyMap.h
+++ b/Project Files/DLLSources/CyMap.h
@@ -45,6 +45,8 @@ public:
 	int plotY(int iIndex);
 	int getGridWidth();
 	int getGridHeight();
+	int getGlobeviewPadWest();
+	int getGlobeviewPadSouth();
 
 	int getLandPlots();
 	int getOwnedPlots();

--- a/Project Files/DLLSources/CyMapInterface1.cpp
+++ b/Project Files/DLLSources/CyMapInterface1.cpp
@@ -40,6 +40,8 @@ void CyMapPythonInterface1(python::class_<CyMap>& x)
 		.def("plotY", &CyMap::plotY, "int (iIndex) - given the index of a plot, returns its Y coordinate")
 		.def("getGridWidth", &CyMap::getGridWidth, "int () - the width of the map, in plots")
 		.def("getGridHeight", &CyMap::getGridHeight, "int () - the height of the map, in plots")
+		.def("getGlobeviewPadWest", &CyMap::getGlobeviewPadWest, "int () - west ocean columns inserted for globe view")
+		.def("getGlobeviewPadSouth", &CyMap::getGlobeviewPadSouth, "int () - south ocean rows inserted for globe view")
 
 		.def("getLandPlots", &CyMap::getLandPlots, "int () - total land plots")
 		.def("getOwnedPlots", &CyMap::getOwnedPlots, "int () - total owned plots")

--- a/Project Files/DLLSources/Events/EventTriggerSavegame.cpp
+++ b/Project Files/DLLSources/Events/EventTriggerSavegame.cpp
@@ -136,6 +136,8 @@ void EventTriggeredData::read(CvSavegameReader& reader)
 		}
 
 	}
+
+	GC.getMap().offsetGlobeviewCoordinates(m_iPlotX, m_iPlotY);
 }
 
 void EventTriggeredData::write(CvSavegameWriter& writer) const
@@ -168,6 +170,7 @@ void EventTriggeredData::readVanilla(CvSavegameReader& reader)
 	reader.Read(m_iCityId);
 	reader.Read(m_iPlotX);
 	reader.Read(m_iPlotY);
+	GC.getMap().offsetGlobeviewCoordinates(m_iPlotX, m_iPlotY);
 	reader.Read(m_iUnitId);
 	reader.Read(m_eOtherPlayer);
 	reader.Read(m_iOtherPlayerCityId);


### PR DESCRIPTION
1. zooming far out on tall maps (Americas Gigantic 136x256) turns globe view black. this is an EXE texture/lighting limit, not a bad map file. Don_Drochilla's workaround of padding ocean to y/x ~ 1.45 gives the full-map zoom. this PR does that padding in the DLL so nobody has to edit the map.

2. extra ocean is split on both coasts: half west, half east (and south/north on wide maps). east-only pad made east-coast starts sail farther to Europe than west-coast starts. Americas Gigantic 136x256 becomes 177x256 with 20 west + 21 east ocean columns.

3. unpadded saves are shifted, not left with x,y pointing at the new west ocean. plot data is read into the interior, then cities, units, starting plots, move-to missions, AI mission/attack plots, event plots, and extra-yield plots get the same west/south offset. plot-index caches (AI distance map, best yield plots) are remapped or rebuilt. already-padded 177-wide saves are left alone (ratio is already safe).

4. WB scenarios get the same offset after rebuild, so file coords land on the interior and both new edges copy Europe from the old edges.

5. GLOBE_SPOTLIGHT_ANGLE stays at 30 on huge world sizes instead of interpolating to 90, so lighting does not go edge-on. random gigantic is already 127x184 and is left alone.

6. needs a new DLL. restart the game, then load the save (or start a new game). after you save once, the extra ocean is stored in the save.

7. playtested on an Americas Gigantic save from develop. max zoom-out shows the whole map, no black globe.