### PR TITLE
Use 2-plot city radius on Americas Gigantic

### DIFF
--- a/PrivateMaps/Americas Gigantic.ColonizationWBSave
+++ b/PrivateMaps/Americas Gigantic.ColonizationWBSave
@@ -1563,6 +1563,7 @@ BeginMap
 	Randomize Features=true
 	Randomize Resources=true
 	Randomize Goodies=true
+	City Catchment Radius=2
 EndMap
 
 ### Plot Info ###


### PR DESCRIPTION
1. Americas Gigantic (136x256) had no City Catchment Radius in the WB file, so colonies used 1-plot / user settings.

2. set City Catchment Radius=2, same as Unknown Continents Massive and Undiscovered World Gigantic.

3. map file only. new game from the scenario. no new DLL.