### PR TITLE
Domestic advisor: red production when buildings/units wait for goods

### DIFF
--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -28204,12 +28204,7 @@ def applyThreeGalleonsRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	(city, iter) = player.firstCity(True)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass)
 
 
 def getHelpThreeGalleonsRewardShip(argsList):

--- a/Assets/Python/Screens/CvDomesticAdvisor.py
+++ b/Assets/Python/Screens/CvDomesticAdvisor.py
@@ -361,11 +361,14 @@ class CvDomesticAdvisor:
 		return False
 
 	def getWaitingProductionNames(self, pCity):
-		# 1. WTP keeps hammers when you switch production. Schmiddie: also
-		#    flag those parked buildings/units when they still need cargo.
+		# WTP keeps hammers when production is switched.
+		# Only list parked buildings/units whose required hammer production is complete
+		# and whose production can still be continued by this city.
+		pPlayer = gc.getPlayer(pCity.getOwner())
 		aNames = []
 		iCurrentBuilding = -1
 		iCurrentUnit = -1
+
 		if pCity.isProductionBuilding():
 			iCurrentBuilding = pCity.getProductionBuilding()
 		elif pCity.isProductionUnit():
@@ -376,18 +379,44 @@ class CvDomesticAdvisor:
 				continue
 			if pCity.isHasBuilding(iBuilding):
 				continue
-			if pCity.getBuildingProduction(iBuilding) <= 0:
+
+			iProduction = pCity.getBuildingProduction(iBuilding)
+			if iProduction <= 0:
 				continue
+
+			iNeeded = pPlayer.getBuildingYieldProductionNeeded(iBuilding, YieldTypes.YIELD_HAMMERS)
+			if iProduction < iNeeded:
+				continue
+
+			if not pCity.canConstruct(iBuilding, True, False, True):
+				continue
+
+			szName = gc.getBuildingInfo(iBuilding).getDescription()
 			if self.productionNeedsCargo(pCity, iBuilding, True):
-				aNames.append(gc.getBuildingInfo(iBuilding).getDescription())
+				szName = "<color=255,0,0>" + szName + "</color>"
+
+			aNames.append(szName)
 
 		for iUnit in range(gc.getNumUnitInfos()):
 			if iUnit == iCurrentUnit:
 				continue
-			if pCity.getUnitProduction(iUnit) <= 0:
+
+			iProduction = pCity.getUnitProduction(iUnit)
+			if iProduction <= 0:
 				continue
+
+			iNeeded = pPlayer.getUnitYieldProductionNeeded(iUnit, YieldTypes.YIELD_HAMMERS)
+			if iProduction < iNeeded:
+				continue
+
+			if not pCity.canTrain(iUnit, True, False):
+				continue
+
+			szName = gc.getUnitInfo(iUnit).getDescription()
 			if self.productionNeedsCargo(pCity, iUnit, False):
-				aNames.append(gc.getUnitInfo(iUnit).getDescription())
+				szName = "<color=255,0,0>" + szName + "</color>"
+
+			aNames.append(szName)
 
 		return aNames
 
@@ -460,7 +489,7 @@ class CvDomesticAdvisor:
 			if len(aWaiting) > 0:
 				if szText != "":
 					szText = szText + " "
-				szText = szText + "<color=255,0,0>[" + u", ".join(aWaiting) + "]</color>"
+				szText = szText + "[" + u", ".join(aWaiting) + "]"
 			screen.setTableText(szState + "ListBackground", 17, i, "<font=2>" + szText + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
 
 		elif(self.CurrentState == self.PRODUCTION_STATE):

--- a/Assets/Python/Screens/CvDomesticAdvisor.py
+++ b/Assets/Python/Screens/CvDomesticAdvisor.py
@@ -347,6 +347,50 @@ class CvDomesticAdvisor:
 			screen.show(self.StatePages[self.CurrentState][self.CurrentPage] + "ListBackground")
 		self.updateAppropriateCitySelection()
 
+	def productionNeedsCargo(self, pCity, iType, bBuilding):
+		pPlayer = gc.getPlayer(pCity.getOwner())
+		for iYield in range(YieldTypes.NUM_YIELD_TYPES):
+			if not gc.getYieldInfo(iYield).isCargo():
+				continue
+			if bBuilding:
+				iNeeded = pPlayer.getBuildingYieldProductionNeeded(iType, iYield)
+			else:
+				iNeeded = pPlayer.getUnitYieldProductionNeeded(iType, iYield)
+			if iNeeded > pCity.getYieldStored(iYield) + pCity.getYieldRushed(iYield):
+				return True
+		return False
+
+	def getWaitingProductionNames(self, pCity):
+		# 1. WTP keeps hammers when you switch production. Schmiddie: also
+		#    flag those parked buildings/units when they still need cargo.
+		aNames = []
+		iCurrentBuilding = -1
+		iCurrentUnit = -1
+		if pCity.isProductionBuilding():
+			iCurrentBuilding = pCity.getProductionBuilding()
+		elif pCity.isProductionUnit():
+			iCurrentUnit = pCity.getProductionUnit()
+
+		for iBuilding in range(gc.getNumBuildingInfos()):
+			if iBuilding == iCurrentBuilding:
+				continue
+			if pCity.isHasBuilding(iBuilding):
+				continue
+			if pCity.getBuildingProduction(iBuilding) <= 0:
+				continue
+			if self.productionNeedsCargo(pCity, iBuilding, True):
+				aNames.append(gc.getBuildingInfo(iBuilding).getDescription())
+
+		for iUnit in range(gc.getNumUnitInfos()):
+			if iUnit == iCurrentUnit:
+				continue
+			if pCity.getUnitProduction(iUnit) <= 0:
+				continue
+			if self.productionNeedsCargo(pCity, iUnit, False):
+				aNames.append(gc.getUnitInfo(iUnit).getDescription())
+
+		return aNames
+
 	def updateCityTable(self, pLoopCity, i):
 		screen = CyGInterfaceScreen( "DomesticAdvisor", CvScreenEnums.DOMESTIC_ADVISOR )
 
@@ -399,7 +443,25 @@ class CvDomesticAdvisor:
 			elif (pLoopCity.getCityHealth() < 0):
 				screen.setTableInt(szState + "ListBackground", 16, i, "<font=2>" + "<color=255,0,0>" +unicode(pLoopCity.getCityHealth()) + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
 			# Producing
-			screen.setTableText(szState + "ListBackground", 17, i, "<font=2>" + pLoopCity.getProductionName() + " (" + str(pLoopCity.getGeneralProductionTurnsLeft()) + ")" + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
+			# Ellestar: red if the current build/unit is missing cargo.
+			# 2. parked production with stored hammers is listed in red too.
+			szName = pLoopCity.getProductionName()
+			szText = u""
+			if szName != "":
+				szText = szName + " (" + str(pLoopCity.getGeneralProductionTurnsLeft()) + ")"
+			bCurrentNeedsCargo = False
+			if pLoopCity.isProductionBuilding():
+				bCurrentNeedsCargo = self.productionNeedsCargo(pLoopCity, pLoopCity.getProductionBuilding(), True)
+			elif pLoopCity.isProductionUnit():
+				bCurrentNeedsCargo = self.productionNeedsCargo(pLoopCity, pLoopCity.getProductionUnit(), False)
+			if bCurrentNeedsCargo and szText != "":
+				szText = "<color=255,0,0>" + szText + "</color>"
+			aWaiting = self.getWaitingProductionNames(pLoopCity)
+			if len(aWaiting) > 0:
+				if szText != "":
+					szText = szText + " "
+				szText = szText + "<color=255,0,0>[" + u", ".join(aWaiting) + "]</color>"
+			screen.setTableText(szState + "ListBackground", 17, i, "<font=2>" + szText + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
 
 		elif(self.CurrentState == self.PRODUCTION_STATE):
 			start = self.YieldStart()

--- a/Assets/Python/Screens/CvMilitaryAdvisor.py
+++ b/Assets/Python/Screens/CvMilitaryAdvisor.py
@@ -77,7 +77,9 @@ class CvMilitaryAdvisor:
 		self.LEADER_BUTTON_SIZE = 64
 		self.LEADER_MARGIN = 12
 
-		self.GROUPING_SELECTION = self.PROFESSION_GROUP_ID
+		# 1. F5 used to open on Sort by Profession. Sort by Unit is what you
+		#    actually want most of the time (SKILL_GROUP_ID = unit type).
+		self.GROUPING_SELECTION = self.SKILL_GROUP_ID
 
 		self.GROUP_TOGGLE = 100
 		self.UNIT_TOGGLE = 200
@@ -141,7 +143,7 @@ class CvMilitaryAdvisor:
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_PROFESSION_SORT", ()), self.PROFESSION_GROUP_ID, self.PROFESSION_GROUP_ID, False)
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_OWNER_SORT", ()), self.OWNER_GROUP_ID, self.OWNER_GROUP_ID, False)
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_STACK_SORT", ()), self.STACK_GROUP_ID, self.STACK_GROUP_ID, False)
-		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_SKILL_SORT", ()), self.SKILL_GROUP_ID, self.SKILL_GROUP_ID, False)
+		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_SKILL_SORT", ()), self.SKILL_GROUP_ID, self.SKILL_GROUP_ID, True)
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_TERRITORY_SORT", ()), self.LOCATION_GROUP_ID, self.LOCATION_GROUP_ID, False)
 
 		self.szHeader = self.getNextWidgetName()

--- a/Project Files/DLLSources/CvCity.cpp
+++ b/Project Files/DLLSources/CvCity.cpp
@@ -4797,6 +4797,9 @@ void CvCity::setYieldStored(YieldTypes eYield, int iValue)
 		CvString szTitle(gDLL->getText("TXT_KEY_ERROR_NEGATIVE_YIELD_STORAGE_TITLE"));
 
 		gDLL->MessageBox(szDesc.c_str(), szTitle.c_str());
+
+		// Never allow negative non-food yield storage.
+		iValue = 0;
 	}
 
 	int iChange = iValue - getYieldStored(eYield);


### PR DESCRIPTION
1. this picks up Ellestar's #1208. F4 general page, production column: the current building/unit goes red if the city does not have the cargo yields needed to finish it (tools, lumber, etc). same idea as the city production bar turning red.

2. Schmiddie pointed out WTP keeps stored hammers when you switch production. those parked buildings/units were invisible because getProductionBuilding / getProductionUnit only see the current queue item. they now show in red brackets after the current production, e.g. `Caravel (4) [Drydock, Wagon]`.

3. uses stored + rushed yields, same as the DLL checkRequiredYields. skips already-built buildings. idle cities with parked work still show the bracket list.

4. python only. restart the game (or reload the mod). no new DLL.

Supersedes #1208 once this is merged (we cannot push to Ellestar's branch).