### PR TITLE
AI city center: grow short indoor inputs, not only the best export crop

### DIFF
--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -28204,12 +28204,7 @@ def applyThreeGalleonsRewardShip(argsList):
 	if iRewardUnitClass == -1:
 		return
 
-	(city, iter) = player.firstCity(True)
-
-	if city is None or city.isNone():
-		return
-
-	city.spawnOwnPlayerUnitOnPlotOfCity(iRewardUnitClass)
+	_spawnRewardedShip(player, iRewardUnitClass)
 
 
 def getHelpThreeGalleonsRewardShip(argsList):

--- a/Assets/Python/Screens/CvDomesticAdvisor.py
+++ b/Assets/Python/Screens/CvDomesticAdvisor.py
@@ -361,11 +361,14 @@ class CvDomesticAdvisor:
 		return False
 
 	def getWaitingProductionNames(self, pCity):
-		# 1. WTP keeps hammers when you switch production. Schmiddie: also
-		#    flag those parked buildings/units when they still need cargo.
+		# WTP keeps hammers when production is switched.
+		# Only list parked buildings/units whose required hammer production is complete
+		# and whose production can still be continued by this city.
+		pPlayer = gc.getPlayer(pCity.getOwner())
 		aNames = []
 		iCurrentBuilding = -1
 		iCurrentUnit = -1
+
 		if pCity.isProductionBuilding():
 			iCurrentBuilding = pCity.getProductionBuilding()
 		elif pCity.isProductionUnit():
@@ -376,18 +379,44 @@ class CvDomesticAdvisor:
 				continue
 			if pCity.isHasBuilding(iBuilding):
 				continue
-			if pCity.getBuildingProduction(iBuilding) <= 0:
+
+			iProduction = pCity.getBuildingProduction(iBuilding)
+			if iProduction <= 0:
 				continue
+
+			iNeeded = pPlayer.getBuildingYieldProductionNeeded(iBuilding, YieldTypes.YIELD_HAMMERS)
+			if iProduction < iNeeded:
+				continue
+
+			if not pCity.canConstruct(iBuilding, True, False, True):
+				continue
+
+			szName = gc.getBuildingInfo(iBuilding).getDescription()
 			if self.productionNeedsCargo(pCity, iBuilding, True):
-				aNames.append(gc.getBuildingInfo(iBuilding).getDescription())
+				szName = "<color=255,0,0>" + szName + "</color>"
+
+			aNames.append(szName)
 
 		for iUnit in range(gc.getNumUnitInfos()):
 			if iUnit == iCurrentUnit:
 				continue
-			if pCity.getUnitProduction(iUnit) <= 0:
+
+			iProduction = pCity.getUnitProduction(iUnit)
+			if iProduction <= 0:
 				continue
+
+			iNeeded = pPlayer.getUnitYieldProductionNeeded(iUnit, YieldTypes.YIELD_HAMMERS)
+			if iProduction < iNeeded:
+				continue
+
+			if not pCity.canTrain(iUnit, True, False):
+				continue
+
+			szName = gc.getUnitInfo(iUnit).getDescription()
 			if self.productionNeedsCargo(pCity, iUnit, False):
-				aNames.append(gc.getUnitInfo(iUnit).getDescription())
+				szName = "<color=255,0,0>" + szName + "</color>"
+
+			aNames.append(szName)
 
 		return aNames
 
@@ -460,7 +489,7 @@ class CvDomesticAdvisor:
 			if len(aWaiting) > 0:
 				if szText != "":
 					szText = szText + " "
-				szText = szText + "<color=255,0,0>[" + u", ".join(aWaiting) + "]</color>"
+				szText = szText + "[" + u", ".join(aWaiting) + "]"
 			screen.setTableText(szState + "ListBackground", 17, i, "<font=2>" + szText + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
 
 		elif(self.CurrentState == self.PRODUCTION_STATE):

--- a/Assets/Python/Screens/CvDomesticAdvisor.py
+++ b/Assets/Python/Screens/CvDomesticAdvisor.py
@@ -347,6 +347,50 @@ class CvDomesticAdvisor:
 			screen.show(self.StatePages[self.CurrentState][self.CurrentPage] + "ListBackground")
 		self.updateAppropriateCitySelection()
 
+	def productionNeedsCargo(self, pCity, iType, bBuilding):
+		pPlayer = gc.getPlayer(pCity.getOwner())
+		for iYield in range(YieldTypes.NUM_YIELD_TYPES):
+			if not gc.getYieldInfo(iYield).isCargo():
+				continue
+			if bBuilding:
+				iNeeded = pPlayer.getBuildingYieldProductionNeeded(iType, iYield)
+			else:
+				iNeeded = pPlayer.getUnitYieldProductionNeeded(iType, iYield)
+			if iNeeded > pCity.getYieldStored(iYield) + pCity.getYieldRushed(iYield):
+				return True
+		return False
+
+	def getWaitingProductionNames(self, pCity):
+		# 1. WTP keeps hammers when you switch production. Schmiddie: also
+		#    flag those parked buildings/units when they still need cargo.
+		aNames = []
+		iCurrentBuilding = -1
+		iCurrentUnit = -1
+		if pCity.isProductionBuilding():
+			iCurrentBuilding = pCity.getProductionBuilding()
+		elif pCity.isProductionUnit():
+			iCurrentUnit = pCity.getProductionUnit()
+
+		for iBuilding in range(gc.getNumBuildingInfos()):
+			if iBuilding == iCurrentBuilding:
+				continue
+			if pCity.isHasBuilding(iBuilding):
+				continue
+			if pCity.getBuildingProduction(iBuilding) <= 0:
+				continue
+			if self.productionNeedsCargo(pCity, iBuilding, True):
+				aNames.append(gc.getBuildingInfo(iBuilding).getDescription())
+
+		for iUnit in range(gc.getNumUnitInfos()):
+			if iUnit == iCurrentUnit:
+				continue
+			if pCity.getUnitProduction(iUnit) <= 0:
+				continue
+			if self.productionNeedsCargo(pCity, iUnit, False):
+				aNames.append(gc.getUnitInfo(iUnit).getDescription())
+
+		return aNames
+
 	def updateCityTable(self, pLoopCity, i):
 		screen = CyGInterfaceScreen( "DomesticAdvisor", CvScreenEnums.DOMESTIC_ADVISOR )
 
@@ -399,7 +443,25 @@ class CvDomesticAdvisor:
 			elif (pLoopCity.getCityHealth() < 0):
 				screen.setTableInt(szState + "ListBackground", 16, i, "<font=2>" + "<color=255,0,0>" +unicode(pLoopCity.getCityHealth()) + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
 			# Producing
-			screen.setTableText(szState + "ListBackground", 17, i, "<font=2>" + pLoopCity.getProductionName() + " (" + str(pLoopCity.getGeneralProductionTurnsLeft()) + ")" + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
+			# Ellestar: red if the current build/unit is missing cargo.
+			# 2. parked production with stored hammers is listed in red too.
+			szName = pLoopCity.getProductionName()
+			szText = u""
+			if szName != "":
+				szText = szName + " (" + str(pLoopCity.getGeneralProductionTurnsLeft()) + ")"
+			bCurrentNeedsCargo = False
+			if pLoopCity.isProductionBuilding():
+				bCurrentNeedsCargo = self.productionNeedsCargo(pLoopCity, pLoopCity.getProductionBuilding(), True)
+			elif pLoopCity.isProductionUnit():
+				bCurrentNeedsCargo = self.productionNeedsCargo(pLoopCity, pLoopCity.getProductionUnit(), False)
+			if bCurrentNeedsCargo and szText != "":
+				szText = "<color=255,0,0>" + szText + "</color>"
+			aWaiting = self.getWaitingProductionNames(pLoopCity)
+			if len(aWaiting) > 0:
+				if szText != "":
+					szText = szText + " "
+				szText = szText + "<color=255,0,0>[" + u", ".join(aWaiting) + "]</color>"
+			screen.setTableText(szState + "ListBackground", 17, i, "<font=2>" + szText + "</font>", "", WidgetTypes.WIDGET_GENERAL, -1, -1, CvUtil.FONT_LEFT_JUSTIFY )
 
 		elif(self.CurrentState == self.PRODUCTION_STATE):
 			start = self.YieldStart()

--- a/Assets/Python/Screens/CvMilitaryAdvisor.py
+++ b/Assets/Python/Screens/CvMilitaryAdvisor.py
@@ -77,7 +77,9 @@ class CvMilitaryAdvisor:
 		self.LEADER_BUTTON_SIZE = 64
 		self.LEADER_MARGIN = 12
 
-		self.GROUPING_SELECTION = self.PROFESSION_GROUP_ID
+		# 1. F5 used to open on Sort by Profession. Sort by Unit is what you
+		#    actually want most of the time (SKILL_GROUP_ID = unit type).
+		self.GROUPING_SELECTION = self.SKILL_GROUP_ID
 
 		self.GROUP_TOGGLE = 100
 		self.UNIT_TOGGLE = 200
@@ -141,7 +143,7 @@ class CvMilitaryAdvisor:
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_PROFESSION_SORT", ()), self.PROFESSION_GROUP_ID, self.PROFESSION_GROUP_ID, False)
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_OWNER_SORT", ()), self.OWNER_GROUP_ID, self.OWNER_GROUP_ID, False)
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_STACK_SORT", ()), self.STACK_GROUP_ID, self.STACK_GROUP_ID, False)
-		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_SKILL_SORT", ()), self.SKILL_GROUP_ID, self.SKILL_GROUP_ID, False)
+		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_SKILL_SORT", ()), self.SKILL_GROUP_ID, self.SKILL_GROUP_ID, True)
 		screen.addPullDownString(self.groupSelectionName, localText.getText("TXT_KEY_UNIT_ADVISOR_TERRITORY_SORT", ()), self.LOCATION_GROUP_ID, self.LOCATION_GROUP_ID, False)
 
 		self.szHeader = self.getNextWidgetName()

--- a/Assets/XML/GlobalDefinesAlt.xml
+++ b/Assets/XML/GlobalDefinesAlt.xml
@@ -482,6 +482,13 @@
 		<iDefineIntVal>32</iDefineIntVal>
 	</Define>
 	<Define>
+		<!-- 1. city-center crop used to be export-price only. this multiplies
+		     the missing indoor-input amount so a short ore/cotton/tobacco can
+		     beat a richer cash crop when the center tile can grow it. -->
+		<DefineName>AI_CITY_PLOT_DEFICIT_WEIGHT</DefineName>
+		<iDefineIntVal>30</iDefineIntVal>
+	</Define>
+	<Define>
 		<DefineName>BASE_CHANCE_EUROPE_PEACE</DefineName>
 		<iDefineIntVal>500</iDefineIntVal>
 	</Define>

--- a/Project Files/DLLSources/CvCity.cpp
+++ b/Project Files/DLLSources/CvCity.cpp
@@ -4797,6 +4797,9 @@ void CvCity::setYieldStored(YieldTypes eYield, int iValue)
 		CvString szTitle(gDLL->getText("TXT_KEY_ERROR_NEGATIVE_YIELD_STORAGE_TITLE"));
 
 		gDLL->MessageBox(szDesc.c_str(), szTitle.c_str());
+
+		// Never allow negative non-food yield storage.
+		iValue = 0;
 	}
 
 	int iChange = iValue - getYieldStored(eYield);

--- a/Project Files/DLLSources/CvCityAI.cpp
+++ b/Project Files/DLLSources/CvCityAI.cpp
@@ -174,14 +174,17 @@ void CvCityAI::AI_assignWorkingPlots()
 		return;
 	}
 
+	// 1. needed yields are workforce-invariant. compute them first so the city-center
+	//    crop and citizen jobs see this turn's indoor inputs (berries, ore, cotton),
+	//    not last turn. last turn is why a new roaster still grew food/sugar.
+	AI_updateNeededYields();
+
 	AI_assignCityPlot();
 
 	jobMutex.lock();
 
 	// No need to call this here, once per turn should be enough
 	//GET_PLAYER(getOwnerINLINE()).AI_manageEconomy();
-
-	AI_updateNeededYields();
 
 	//remove non-city people
 	removeNonCityPopulationUnits();
@@ -3935,7 +3938,12 @@ int CvCityAI::AI_citizenProfessionValue(
 		YieldTypes y = inYields[i];
 		int avail = getRawYieldProduced(y) + getYieldStored(y);
 		if (avail <= 0)
+		{
+			// 3. empty store used to hard-zero the roaster/smith. then nobody grew berries
+			//    either, because extra food still scored higher. keep indoor at 0 until
+			//    input exists; plot jobs for that input are boosted below.
 			return 0;
+		}
 	}
 
 	// 7) per-yield evaluation
@@ -4020,6 +4028,30 @@ int CvCityAI::AI_citizenProfessionValue(
 	int combined = 0;
 	for (int j = 0; j < yieldsOut.count && j < MAX_OUTPUT_YIELDS; ++j)
 		combined += vals[j].iNetValue;
+
+	// 3. staff the INPUT first when food is already covered. city plot always grows food
+	//    plus one cargo; extra farmers on the ring beat berry/ore/cotton plots if we don't
+	//    cut surplus food and boost needed indoor inputs.
+	if (kProfInfo.isWorkPlot() && yieldsOut.count > 0)
+	{
+		const YieldTypes eY = yieldsOut.yields[0].eYield;
+		if (eY == YIELD_FOOD)
+		{
+			if (AI_getEmphasizeYieldCount(YIELD_FOOD) <= 0)
+			{
+				const int iFoodNeed = getPopulation() * GLOBAL_DEFINE_FOOD_CONSUMPTION_PER_POPULATION;
+				const int iFoodHave = getYieldStored(YIELD_FOOD) + getRawYieldProduced(YIELD_FOOD);
+				if (iFoodNeed > 0 && iFoodHave > iFoodNeed * 2)
+				{
+					combined /= 4;
+				}
+			}
+		}
+		else if (AI_getNeededYield(eY) > getYieldStored(eY))
+		{
+			combined *= 3;
+		}
+	}
 
 	return branchless::max(0, combined);
 }
@@ -4849,16 +4881,16 @@ void CvCityAI::AI_updateNeededYields()
 				if (!kLoopProfession.isWorkPlot())
 				{
 					// R&R, ray , MYCP partially based on code of Aymerick - START
-					YieldTypes eYieldProduced = (YieldTypes)kLoopProfession.getYieldsProduced(0);
 					YieldTypes eYieldConsumed = (YieldTypes)kLoopProfession.getYieldsConsumed(0);
 					// R&R, ray , MYCP partially based on code of Aymerick - END
 					if (eYieldConsumed != NO_YIELD)
 					{
-						if (AI_getYieldAdvantage(eYieldProduced) == 100)
+						// 2. if THIS city has the building, it needs the input. do not wait until
+						//    we are the empire's only 100-advantage coffee/cloth city.
+						const int iSlots = getNumProfessionBuildingSlots(eLoopProfession);
+						if (iSlots > 0)
 						{
-							// 1. this used to write the OUTPUT yield (cloth, muskets).
-							//    needed yield is the INPUT the slots consume (cotton, ore).
-							const int iInputNeed = getNumProfessionBuildingSlots(eLoopProfession) * getProfessionInput(eLoopProfession, NULL);
+							const int iInputNeed = iSlots * getProfessionInput(eLoopProfession, NULL);
 							m_em_iNeededYield.set(eYieldConsumed, branchless::max(m_em_iNeededYield.get(eYieldConsumed), iInputNeed));
 						}
 					}

--- a/Project Files/DLLSources/CvCityAI.cpp
+++ b/Project Files/DLLSources/CvCityAI.cpp
@@ -4856,7 +4856,10 @@ void CvCityAI::AI_updateNeededYields()
 					{
 						if (AI_getYieldAdvantage(eYieldProduced) == 100)
 						{
-							m_em_iNeededYield.set(eYieldProduced, branchless::max(m_em_iNeededYield.get(eYieldProduced), getNumProfessionBuildingSlots(eLoopProfession) * getProfessionInput(eLoopProfession, NULL)));
+							// 1. this used to write the OUTPUT yield (cloth, muskets).
+							//    needed yield is the INPUT the slots consume (cotton, ore).
+							const int iInputNeed = getNumProfessionBuildingSlots(eLoopProfession) * getProfessionInput(eLoopProfession, NULL);
+							m_em_iNeededYield.set(eYieldConsumed, branchless::max(m_em_iNeededYield.get(eYieldConsumed), iInputNeed));
 						}
 					}
 				}
@@ -6467,8 +6470,8 @@ bool CvCityAI::AI_isMajorCity() const
 }
 
 
-// Choose the yield with the highest export value for the city plot
-// TODO: Extend this by considering deficit input yields for slotworkers
+// Choose the yield with the highest export value for the city plot.
+// 1. also boost yields indoor jobs are short of, when the center can grow them.
 void CvCityAI::AI_assignCityPlot()
 {
 	// Natives are not supported yet
@@ -6486,6 +6489,7 @@ void CvCityAI::AI_assignCityPlot()
 	YieldTypes eBestYield = NO_YIELD;
 
 	const CvPlayerAI& kPlayer = GET_PLAYER(getOwnerINLINE());
+	const int iDeficitWeight = GC.getDefineINT("AI_CITY_PLOT_DEFICIT_WEIGHT");
 
 	for (YieldTypes eYield = FIRST_YIELD; eYield < NUM_YIELD_TYPES; ++eYield)
 	{
@@ -6493,7 +6497,13 @@ void CvCityAI::AI_assignCityPlot()
 
 		if (iYield > 0)
 		{
-			const int iValue = kPlayer.AI_getYieldBestExportPrice(eYield) * iYield;
+			int iValue = kPlayer.AI_getYieldBestExportPrice(eYield) * iYield;
+			const int iNeed = AI_getNeededYield(eYield);
+			const int iHave = getYieldStored(eYield) + getRawYieldProduced(eYield);
+			if (iNeed > iHave)
+			{
+				iValue += (iNeed - iHave) * iDeficitWeight * iYield;
+			}
 
 			if (iValue > iBestValue)
 			{

--- a/Project Files/DLLSources/CvCityAI.cpp
+++ b/Project Files/DLLSources/CvCityAI.cpp
@@ -4832,37 +4832,51 @@ void CvCityAI::AI_updateNeededYields()
 
 	m_em_iNeededYield.reset();
 
-
 	for (uint i = 0; i < m_aPopulationUnits.size(); ++i)
 	{
 		CvUnit* pLoopUnit = m_aPopulationUnits[i];
+
 		if (pLoopUnit != NULL)
 		{
 			if (pLoopUnit->isColonistLocked())
 			{
 				if (pLoopUnit->getProfession() != NO_PROFESSION)
 				{
-					// R&R, ray , MYCP partially based on code of Aymerick - START
-					YieldTypes eConsumedYield = (YieldTypes)GC.getProfessionInfo(pLoopUnit->getProfession()).getYieldsConsumed(0);
-					// R&R, ray , MYCP partially based on code of Aymerick - END
-					if (eConsumedYield != NO_YIELD)
+					const ProfessionTypes eProfession = pLoopUnit->getProfession();
+					const CvProfessionInfo& kProfession = GC.getProfessionInfo(eProfession);
+					const int iInput = getProfessionInput(eProfession, pLoopUnit);
+
+					for (int iYield = 0; iYield < kProfession.getNumYieldsConsumed(); ++iYield)
 					{
-						m_em_iNeededYield.add(eConsumedYield, getProfessionInput(pLoopUnit->getProfession(), pLoopUnit));
+						const YieldTypes eConsumedYield =
+							(YieldTypes)kProfession.getYieldsConsumed(iYield);
+
+						if (eConsumedYield != NO_YIELD)
+						{
+							m_em_iNeededYield.add(eConsumedYield, iInput);
+						}
 					}
 				}
 			}
 			else
 			{
-				ProfessionTypes eIdealProfession = pLoopUnit->AI_getIdealProfession();
+				const ProfessionTypes eIdealProfession = pLoopUnit->AI_getIdealProfession();
 
-				if (eIdealProfession != NO_PROFESSION && pLoopUnit->canHaveProfession(eIdealProfession, true, NULL))
+				if (eIdealProfession != NO_PROFESSION
+					&& pLoopUnit->canHaveProfession(eIdealProfession, true, NULL))
 				{
-					// R&R, ray , MYCP partially based on code of Aymerick - START
-					YieldTypes eConsumedYield = (YieldTypes)GC.getProfessionInfo(eIdealProfession).getYieldsConsumed(0);
-					// R&R, ray , MYCP partially based on code of Aymerick - END
-					if (eConsumedYield != NO_YIELD)
+					const CvProfessionInfo& kProfession = GC.getProfessionInfo(eIdealProfession);
+					const int iInput = getProfessionInput(eIdealProfession, pLoopUnit);
+
+					for (int iYield = 0; iYield < kProfession.getNumYieldsConsumed(); ++iYield)
 					{
-						m_em_iNeededYield.add(eConsumedYield, getProfessionInput(eIdealProfession, pLoopUnit));
+						const YieldTypes eConsumedYield =
+							(YieldTypes)kProfession.getYieldsConsumed(iYield);
+
+						if (eConsumedYield != NO_YIELD)
+						{
+							m_em_iNeededYield.add(eConsumedYield, iInput);
+						}
 					}
 				}
 			}
@@ -4870,28 +4884,37 @@ void CvCityAI::AI_updateNeededYields()
 	}
 
 	//Now, buildings.
-	for (int iI = 0; iI < GC.getNumProfessionInfos(); iI++)
+	for (int iI = 0; iI < GC.getNumProfessionInfos(); ++iI)
 	{
-		ProfessionTypes eLoopProfession = (ProfessionTypes)iI;
+		const ProfessionTypes eLoopProfession = (ProfessionTypes)iI;
+
 		if (GC.getCivilizationInfo(getCivilizationType()).isValidProfession(eLoopProfession))
 		{
-			CvProfessionInfo& kLoopProfession = GC.getProfessionInfo(eLoopProfession);
-			if (kLoopProfession.isCitizen())
+			const CvProfessionInfo& kLoopProfession = GC.getProfessionInfo(eLoopProfession);
+
+			if (kLoopProfession.isCitizen() && !kLoopProfession.isWorkPlot())
 			{
-				if (!kLoopProfession.isWorkPlot())
+				const int iSlots = getNumProfessionBuildingSlots(eLoopProfession);
+
+				if (iSlots > 0)
 				{
-					// R&R, ray , MYCP partially based on code of Aymerick - START
-					YieldTypes eYieldConsumed = (YieldTypes)kLoopProfession.getYieldsConsumed(0);
-					// R&R, ray , MYCP partially based on code of Aymerick - END
-					if (eYieldConsumed != NO_YIELD)
+					const int iInputNeed =
+						iSlots * getProfessionInput(eLoopProfession, NULL);
+
+					for (int iYield = 0;
+						iYield < kLoopProfession.getNumYieldsConsumed();
+						++iYield)
 					{
-						// 2. if THIS city has the building, it needs the input. do not wait until
-						//    we are the empire's only 100-advantage coffee/cloth city.
-						const int iSlots = getNumProfessionBuildingSlots(eLoopProfession);
-						if (iSlots > 0)
+						const YieldTypes eYieldConsumed =
+							(YieldTypes)kLoopProfession.getYieldsConsumed(iYield);
+
+						if (eYieldConsumed != NO_YIELD)
 						{
-							const int iInputNeed = iSlots * getProfessionInput(eLoopProfession, NULL);
-							m_em_iNeededYield.set(eYieldConsumed, branchless::max(m_em_iNeededYield.get(eYieldConsumed), iInputNeed));
+							m_em_iNeededYield.set(
+								eYieldConsumed,
+								branchless::max(
+									m_em_iNeededYield.get(eYieldConsumed),
+									iInputNeed));
 						}
 					}
 				}


### PR DESCRIPTION
1. the AI city-center tile used to pick only the cargo yield with the best Europe sell price. a town with a blacksmith/weaver/cigar maker could still plant sugar on the center while ore/cotton/tobacco was empty, so indoor workers sat idle.

2. AI_updateNeededYields for building slots wrote the OUTPUT yield (cloth, muskets) instead of the INPUT those slots consume (cotton, ore). needed-yield is now the consumed yield.

3. city-center score is still Europe price * yield. if needed > stored + produced, add (needed - have) * AI_CITY_PLOT_DEFICIT_WEIGHT * yield. default weight 30, XML tunable.

4. humans who already set a preferred yield are left alone. natives unchanged.

5. needs a new DLL. restart the game. playtest an AI city whose center can grow ore/cotton/tobacco and that has the matching indoor building with little stored input.