### PR TITLE
AI attack stacks prefer a nearby city; assault ratio is XML

### DIFF
--- a/Assets/XML/GlobalDefinesAlt.xml
+++ b/Assets/XML/GlobalDefinesAlt.xml
@@ -482,6 +482,19 @@
 		<iDefineIntVal>32</iDefineIntVal>
 	</Define>
 	<Define>
+		<!-- 1. colonial stacks used 120%, natives 80%, hardcoded. nearby path was 12 for natives only. -->
+		<DefineName>AI_STACK_ATTACK_RATIO</DefineName>
+		<iDefineIntVal>120</iDefineIntVal>
+	</Define>
+	<Define>
+		<DefineName>AI_NATIVE_STACK_ATTACK_RATIO</DefineName>
+		<iDefineIntVal>80</iDefineIntVal>
+	</Define>
+	<Define>
+		<DefineName>AI_STACK_ATTACK_NEAR_PATH_TURNS</DefineName>
+		<iDefineIntVal>12</iDefineIntVal>
+	</Define>
+	<Define>
 		<DefineName>BASE_CHANCE_EUROPE_PEACE</DefineName>
 		<iDefineIntVal>500</iDefineIntVal>
 	</Define>

--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -2850,24 +2850,33 @@ void CvUnitAI::AI_attackCityMove()
 	}
 
 	CvCity* pTargetCity = NULL;
+	const int iNearPathTurns = std::max(1, GC.getDefineINT("AI_STACK_ATTACK_NEAR_PATH_TURNS"));
 	if( isNative() )
 	{
-		pTargetCity = AI_pickTargetCity(0, 12);
+		pTargetCity = AI_pickTargetCity(0, iNearPathTurns);
 	}
 	else
 	{
-		// BBAI TODO: Find some way of reliably targetting nearby cities with less defense ...
-		pTargetCity = AI_pickTargetCity(0, MAX_INT, bHuntBarbs);
+		// 1. nearby city first (same path cap natives already used). far capital only if nothing is in range.
+		pTargetCity = AI_pickTargetCity(0, iNearPathTurns, bHuntBarbs);
+		if (pTargetCity == NULL)
+		{
+			pTargetCity = AI_pickTargetCity(0, MAX_INT, bHuntBarbs);
+		}
 	}
 
 	if( pTargetCity != NULL )
 	{
 		int iStepDistToTarget = stepDistance(pTargetCity->getX_INLINE(), pTargetCity->getY_INLINE(), getX_INLINE(), getY_INLINE());
-		int iAttackRatio = 120;
+		int iAttackRatio = GC.getDefineINT("AI_STACK_ATTACK_RATIO");
 
 		if( isNative() )
 		{
-			iAttackRatio = 80;
+			iAttackRatio = GC.getDefineINT("AI_NATIVE_STACK_ATTACK_RATIO");
+		}
+		if (iAttackRatio <= 0)
+		{
+			iAttackRatio = isNative() ? 80 : 120;
 		}
 
 		int iComparePostBombard = 0;
@@ -2930,7 +2939,6 @@ void CvUnitAI::AI_attackCityMove()
 					//stack attack
 					if (getGroup()->getNumUnits() > 1)
 					{
-						// BBAI TODO: What is right ratio?
 						if (AI_stackAttackCity(1, iAttackRatio, true))
 						{
 							return;

--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -2850,14 +2850,32 @@ void CvUnitAI::AI_attackCityMove()
 	}
 
 	CvCity* pTargetCity = NULL;
-	const int iNearPathTurns = std::max(1, GC.getDefineINT("AI_STACK_ATTACK_NEAR_PATH_TURNS"));
+	// 1. XML is the Standard-map nearby path cap (turns, not tiles). scale by actual map height
+	//    so huge/gigantic still see a local city before falling back to a far capital.
+	int iNearPathTurns = GC.getDefineINT("AI_STACK_ATTACK_NEAR_PATH_TURNS");
+	if (iNearPathTurns <= 0)
+	{
+		iNearPathTurns = 12;
+	}
+	{
+		const int iStdHeight = std::max(1, GC.getWorldInfo(WORLDSIZE_STANDARD).getGridHeight());
+		const int iMapHeight = std::max(1, GC.getMap().getGridHeightINLINE());
+		iNearPathTurns = (iNearPathTurns * iMapHeight + iStdHeight / 2) / iStdHeight;
+		if (iNearPathTurns < 8)
+		{
+			iNearPathTurns = 8;
+		}
+		else if (iNearPathTurns > 24)
+		{
+			iNearPathTurns = 24;
+		}
+	}
 	if( isNative() )
 	{
 		pTargetCity = AI_pickTargetCity(0, iNearPathTurns);
 	}
 	else
 	{
-		// 1. nearby city first (same path cap natives already used). far capital only if nothing is in range.
 		pTargetCity = AI_pickTargetCity(0, iNearPathTurns, bHuntBarbs);
 		if (pTargetCity == NULL)
 		{

--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -2858,7 +2858,11 @@ void CvUnitAI::AI_attackCityMove()
 		iNearPathTurns = 12;
 	}
 	{
-		const int iStdHeight = 64; // WORLDSIZE_STANDARD iGridHeight
+		// 2. 64 is WORLDSIZE_STANDARD iGridHeight in CIV4WorldInfo.xml. do not call
+		//    GC.getWorldInfo(WORLDSIZE_STANDARD).getGridHeight() from this cpp:
+		//    WORLDSIZE_STANDARD is an AutoXml enum and is not declared here. VC++ 2003
+		//    then fails C2065 and the std::max line after it.
+		const int iStdHeight = 64;
 		const int iMapHeight = std::max(1, GC.getMap().getGridHeightINLINE());
 		iNearPathTurns = (iNearPathTurns * iMapHeight + iStdHeight / 2) / iStdHeight;
 		if (iNearPathTurns < 8)

--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -2858,7 +2858,7 @@ void CvUnitAI::AI_attackCityMove()
 		iNearPathTurns = 12;
 	}
 	{
-		const int iStdHeight = std::max(1, GC.getWorldInfo(WORLDSIZE_STANDARD).getGridHeight());
+		const int iStdHeight = 64; // WORLDSIZE_STANDARD iGridHeight
 		const int iMapHeight = std::max(1, GC.getMap().getGridHeightINLINE());
 		iNearPathTurns = (iNearPathTurns * iMapHeight + iStdHeight / 2) / iStdHeight;
 		if (iNearPathTurns < 8)


### PR DESCRIPTION
1. colonial UNITAI_OFFENSIVE stacks called AI_pickTargetCity with MAX_INT, so a stack in Virginia could march to Peru. natives already capped path at 12. colonial stacks now try a nearby cap first, then fall back to the whole map if nothing is in range.

2. that nearby cap is path TURNS, not tiles. XML AI_STACK_ATTACK_NEAR_PATH_TURNS (default 12) is the Standard-map value. it is scaled by actual map height / Standard height (64), then clamped 8-24. tiny ~8, standard 12, huge ~19, gigantic 24. globe west/east pad does not inflate this because it uses height, not width.

3. the 120% (natives 80%) city-assault power ratio was hardcoded. it is now AI_STACK_ATTACK_RATIO / AI_NATIVE_STACK_ATTACK_RATIO.

4. needs a new DLL. restart the game. playtest a colonial war where a stack has a weak city nearby and a capital far away, including on huge/gigantic.