### PR TITLE
Stop large attack stacks walking 10 turns to absorb one unit

### DIFF
--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -3200,7 +3200,8 @@ void CvUnitAI::AI_attackCityMove()
 		if ((bombardRate() > 0) && noDefensiveBonus())
 		{
 			// BBAI Notes: Add this stack lead by bombard unit to stack probably not lead by a bombard unit
-			// BBAI TODO: Some sense of minimum stack size?  Can have big stack moving 10 turns to merge with tiny stacks
+			// 1. merge path is still 10 max. AI_omniGroup also caps it by relative stack size so a fat stack
+			//    does not walk 10 turns to pick up one unit.
 			if (AI_group(UNITAI_OFFENSIVE, -1, GLOBAL_DEFINE_AI_STACK_OF_DOOM_LIMIT, -1, bIgnoreFaster, true, true, /*iMaxPath*/ 10, /*bAllowRegrouping*/ true))
 			{
 				return;
@@ -10027,6 +10028,19 @@ bool CvUnitAI::AI_omniGroup(UnitAITypes eUnitAI, int iMaxGroup, int iMaxOwnUnitA
 			if (at(kLoopPlot) ||
 				generatePath(&kLoopPlot, eFlags, true, &iPathTurns, iMaxPath))
 			{
+				// 1. big offensive stacks should not walk 10 turns for one stray unit.
+				//    iMaxPath is still the ceiling. allowed path shrinks as we get bigger than them.
+				if (eUnitAI == UNITAI_OFFENSIVE && getDomainType() == DOMAIN_LAND)
+				{
+					const int iUs = getGroup()->getNumUnits();
+					const int iThem = pLoopGroup->getNumUnits();
+					const int iRelPath = 1 + (8 * iThem) / std::max(1, iUs);
+					if (iPathTurns > iRelPath)
+					{
+						continue;
+					}
+				}
+
 				int iCost = 100 * (iPathTurns * iPathTurns + 1);
 				iCost *= 4 + pLoopGroup->getCargo();
 				iCost /= 2 + pLoopGroup->getNumUnits();


### PR DESCRIPTION
1. a bombard-led attack stack called AI_group with iMaxPath=10. a 20-unit army would walk up to 10 turns across the colony to pick up one dragoon. AI_STACK_OF_DOOM_LIMIT (32) only caps merged size, not walk distance.

2. the relative-size path cap has to live in AI_omniGroup because only that function knows the other group's size. iMaxPath=10 is still the ceiling. for land UNITAI_OFFENSIVE joins, a path is rejected if it is longer than 1 + 8 * them / us. a stack of 20 walks 1 tile for 1 unit, and still walks farther to merge with a similarly large group.

3. settler/sea grouping is unchanged (different UNITAI). the empty split-slow-units stub is untouched.

4. needs a new DLL. restart the game. playtest a fat offensive stack with a stray unit 8 tiles away: it should not walk 8 turns to absorb it.