### PR TITLE
Own-land attack stacks fight raiders instead of walking past

### DIFF
--- a/Project Files/DLLSources/CvUnitAI.cpp
+++ b/Project Files/DLLSources/CvUnitAI.cpp
@@ -3007,24 +3007,23 @@ void CvUnitAI::AI_attackCityMove()
 		return;
 	}
 
-	// BBAI TODO: Stack v stack combat ... definitely want to do in own territory, but what about enemy territory?
-	/*
-	if (collateralDamage() > 0 && plot()->getOwnerINLINE() == getOwnerINLINE())
+	// 1. own-land stack vs stack only. BTS gated this on collateralDamage (catapults).
+	//    colonial stacks are dragoons/infantry, so that gate would never fire. enemy land stays on the old 60% anyAttack.
+	if (plot()->getOwnerINLINE() == getOwnerINLINE() && getGroup()->getNumUnits() >= 3)
 	{
-		if (AI_anyAttack(1, 45, 3, false))
+		if (AI_anyAttack(1, 45, 3, false, false))
 		{
 			return;
 		}
 
-		if( !bReadyToAttack )
+		if (!bReadyToAttack)
 		{
-			if (AI_anyAttack(1, 25, 5, false))
+			if (AI_anyAttack(1, 25, 5, false, false))
 			{
 				return;
 			}
 		}
 	}
-	*/
 
 	if (AI_anyAttack(1, 60, 0, false, false))
 	{


### PR DESCRIPTION
1. BBAI left stack-vs-stack combat commented out. the BTS gate was collateralDamage > 0 (catapults). colonial stacks are dragoons/infantry, so uncommenting that as-is would never fire.

2. own land only, group size at least 3: AI_anyAttack(1, 45, 3) then if not ready to assault a city AI_anyAttack(1, 25, 5). this sits above the generic 60% anyAttack.

3. enemy territory is unchanged. 1-2 unit groups are unchanged. the empty split-slow-units stub is untouched.

4. needs a new DLL. restart the game. playtest a war save: our 6-unit stack on our land next to an enemy raid should attack instead of walking toward a city.