### PR TITLE
Stop African and Native slaves from speaking with chiefs

### DIFF
--- a/Project Files/DLLSources/CvUnit.cpp
+++ b/Project Files/DLLSources/CvUnit.cpp
@@ -6991,6 +6991,11 @@ bool CvUnit::canSpeakWithChief(CvPlot* pPlot) const
 	{
 		return false;
 	}
+	// raphaelmonticello 1: chiefs will not speak with African or Native slaves
+	if (getUnitClassType() == UNITCLASS_AFRICAN_SLAVE || getUnitClassType() == UNITCLASS_NATIVE_SLAVE)
+	{
+		return false;
+	}
 	// < JAnimals Mod Start >
 	if (isBarbarian())
 	{

--- a/Project Files/DLLSources/CvUnit.cpp
+++ b/Project Files/DLLSources/CvUnit.cpp
@@ -6991,7 +6991,7 @@ bool CvUnit::canSpeakWithChief(CvPlot* pPlot) const
 	{
 		return false;
 	}
-	// raphaelmonticello 1: chiefs will not speak with African or Native slaves
+	// chiefs will not speak with African or Native slaves
 	if (getUnitClassType() == UNITCLASS_AFRICAN_SLAVE || getUnitClassType() == UNITCLASS_NATIVE_SLAVE)
 	{
 		return false;


### PR DESCRIPTION
African slaves and Native slaves can no longer Speak with Chief. The command is hidden for those units.