### PR TITLE
Skip the war popup for natives; keep it for Europeans

### DIFF
--- a/Assets/Python/CvDiplomacy.py
+++ b/Assets/Python/CvDiplomacy.py
@@ -54,17 +54,13 @@ class CvDiplomacy:
 
 			# We say hi and begin our peace
 			self.addUserComment("USER_DIPLOCOMMENT_PEACE", -1, -1)
-
-			# if you are on different teams and NOT at war, give the user the option to declare war
-			#if (gc.getTeam(gc.getGame().getActiveTeam()).canDeclareWar(gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam())):
-			#	self.addUserComment("USER_DIPLOCOMMENT_WAR", -1, -1)
-
+			self.addDeclareWarCommentIfValid()
 			self.diploScreen.endTrade()
 
 		# The AI refuses to talk
 		elif (self.isComment(eComment, "AI_DIPLOCOMMENT_REFUSE_TO_TALK") ):
 
-			# Give the option to exit
+			self.addDeclareWarCommentIfValid()
 			self.addUserComment("USER_DIPLOCOMMENT_EXIT", -1, -1)
 			self.diploScreen.endTrade();
 
@@ -628,11 +624,7 @@ class CvDiplomacy:
 			self.diploScreen.startTrade( eComment, False )
 
 		elif (self.isComment(eComment, "AI_DIPLOCOMMENT_SOMETHING_ELSE")):
-			if (gc.getTeam(gc.getGame().getActiveTeam()).canDeclareWar(gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam())):
-				if gc.getTeam(gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam()).isParentOf(gc.getGame().getActiveTeam()):
-					self.addUserComment("USER_DIPLOCOMMENT_REVOLUTION", -1, -1)
-				else:
-					self.addUserComment("USER_DIPLOCOMMENT_WAR", -1, -1)
+			self.addDeclareWarCommentIfValid()
 
 			self.addUserComment("USER_DIPLOCOMMENT_ATTITUDE", -1, -1)
 			if (gc.getTeam(gc.getGame().getActiveTeam()).AI_shareWar(gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam())):
@@ -692,8 +684,7 @@ class CvDiplomacy:
 				self.addUserComment("USER_DIPLOCOMMENT_CURRENT_DEALS", -1, -1)
 
 			if (gc.getTeam(gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam())).isParentOf(gc.getGame().getActiveTeam()):
-				if (gc.getTeam(gc.getGame().getActiveTeam()).canDeclareWar(gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam())):
-					self.addUserComment("USER_DIPLOCOMMENT_REVOLUTION", -1, -1)
+				self.addDeclareWarCommentIfValid()
 
 				if (not gc.getTeam(gc.getGame().getActiveTeam()).isAtWar(gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam())):
 					self.addUserComment("USER_DIPLOCOMMENT_BUY_UNITS", -1, -1)
@@ -711,6 +702,16 @@ class CvDiplomacy:
 			# Exit potential
 			self.addUserComment("USER_DIPLOCOMMENT_EXIT", -1, -1)
 			self.diploScreen.endTrade();
+
+	def addDeclareWarCommentIfValid(self):
+		eActiveTeam = gc.getGame().getActiveTeam()
+		eOtherTeam = gc.getPlayer(self.diploScreen.getWhoTradingWith()).getTeam()
+		if not gc.getTeam(eActiveTeam).canDeclareWar(eOtherTeam):
+			return
+		if gc.getTeam(eOtherTeam).isParentOf(eActiveTeam):
+			self.addUserComment("USER_DIPLOCOMMENT_REVOLUTION", -1, -1)
+		else:
+			self.addUserComment("USER_DIPLOCOMMENT_WAR", -1, -1)
 
 	def addUserComment(self, eComment, iData1, iData2, *args):
 		" Helper for adding User Comments "

--- a/Project Files/DLLSources/CvGame.cpp
+++ b/Project Files/DLLSources/CvGame.cpp
@@ -2229,9 +2229,8 @@ void CvGame::selectionListMove(CvPlot* pPlot, bool bAlt, bool bShift, bool bCtrl
 		//if (pSelectedUnit->cargoSpace() == 0 && eRivalTeam != NO_TEAM)
 		if (eRivalTeam != NO_TEAM && (pSelectedUnit->cargoSpace() == 0 || pSelectedUnit->getUnitInfo().isTroopShip()))
 		{
-			// raphaelmonticello 1: Tish wanted this popup gone. moving onto a foreign unit
-			// (or into land that would start a war) no longer asks "does this mean war?".
-			// declare war from the diplomacy screen, then move / attack as usual.
+			// moving onto a foreign unit (or into land that would start a war) no longer
+			// asks "does this mean war?". declare war from the diplomacy screen, then move / attack.
 			return;
 		}
 	}

--- a/Project Files/DLLSources/CvGame.cpp
+++ b/Project Files/DLLSources/CvGame.cpp
@@ -2172,10 +2172,7 @@ bool CvGame::cyclePlotUnits(CvPlot* pPlot, bool bForward, bool bAuto, int iCount
 
 void CvGame::selectionListMove(CvPlot* pPlot, bool bAlt, bool bShift, bool bCtrl)
 {
-	CLLNode<IDInfo>* pSelectedUnitNode;
 	CvUnit* pHeadSelectedUnit;
-	CvUnit* pSelectedUnit;
-	TeamTypes eRivalTeam;
 
 	if (pPlot == NULL)
 	{
@@ -2212,29 +2209,9 @@ void CvGame::selectionListMove(CvPlot* pPlot, bool bAlt, bool bShift, bool bCtrl
 		gDLL->getInterfaceIFace()->selectGroup(pHeadSelectedUnit, false, true, false);
 	}
 
-	pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
-
-	while (pSelectedUnitNode != NULL)
-	{
-		pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
-		pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
-
-		if (pSelectedUnit == NULL)
-			continue;
-
-		eRivalTeam = pSelectedUnit->getDeclareWarUnitMove(pPlot);
-
-		// Erik: No annoying popup for transport units
-		// WTP, ray, unless it is a "Troop only" ship
-		//if (pSelectedUnit->cargoSpace() == 0 && eRivalTeam != NO_TEAM)
-		if (eRivalTeam != NO_TEAM && (pSelectedUnit->cargoSpace() == 0 || pSelectedUnit->getUnitInfo().isTroopShip()))
-		{
-			// moving onto a foreign unit (or into land that would start a war) no longer
-			// asks "does this mean war?". declare war from the diplomacy screen, then move / attack.
-			return;
-		}
-	}
-
+	// No "does this mean war?" popup on move. If the tile can be entered
+	// without war, MOVE_TO goes through; if not, the mission fails until
+	// war is declared from the diplomacy screen.
 	selectionListGameNetMessage(GAMEMESSAGE_PUSH_MISSION, MISSION_MOVE_TO, pPlot->getX(), pPlot->getY(), 0, false, bShift);
 }
 

--- a/Project Files/DLLSources/CvGame.cpp
+++ b/Project Files/DLLSources/CvGame.cpp
@@ -2229,23 +2229,9 @@ void CvGame::selectionListMove(CvPlot* pPlot, bool bAlt, bool bShift, bool bCtrl
 		//if (pSelectedUnit->cargoSpace() == 0 && eRivalTeam != NO_TEAM)
 		if (eRivalTeam != NO_TEAM && (pSelectedUnit->cargoSpace() == 0 || pSelectedUnit->getUnitInfo().isTroopShip()))
 		{
-			CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_DECLAREWARMOVE);
-			if (NULL != pInfo)
-			{
-				pInfo->setData1(eRivalTeam);
-				pInfo->setData2(pPlot->getX());
-				pInfo->setData3(pPlot->getY());
-				pInfo->setOption1(bShift);
-				if (pPlot->isOwned())
-				{
-					pInfo->setOption2(pSelectedUnit->canEnterTerritory(pPlot->getOwnerINLINE()));
-				}
-				else
-				{
-					pInfo->setOption2(true);
-				}
-				gDLL->getInterfaceIFace()->addPopup(pInfo);
-			}
+			// raphaelmonticello 1: Tish wanted this popup gone. moving onto a foreign unit
+			// (or into land that would start a war) no longer asks "does this mean war?".
+			// declare war from the diplomacy screen, then move / attack as usual.
 			return;
 		}
 	}

--- a/Project Files/DLLSources/CvGame.cpp
+++ b/Project Files/DLLSources/CvGame.cpp
@@ -2172,7 +2172,10 @@ bool CvGame::cyclePlotUnits(CvPlot* pPlot, bool bForward, bool bAuto, int iCount
 
 void CvGame::selectionListMove(CvPlot* pPlot, bool bAlt, bool bShift, bool bCtrl)
 {
+	CLLNode<IDInfo>* pSelectedUnitNode;
 	CvUnit* pHeadSelectedUnit;
+	CvUnit* pSelectedUnit;
+	TeamTypes eRivalTeam;
 
 	if (pPlot == NULL)
 	{
@@ -2209,9 +2212,49 @@ void CvGame::selectionListMove(CvPlot* pPlot, bool bAlt, bool bShift, bool bCtrl
 		gDLL->getInterfaceIFace()->selectGroup(pHeadSelectedUnit, false, true, false);
 	}
 
-	// No "does this mean war?" popup on move. If the tile can be entered
-	// without war, MOVE_TO goes through; if not, the mission fails until
-	// war is declared from the diplomacy screen.
+	pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+	while (pSelectedUnitNode != NULL)
+	{
+		pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+		pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+
+		if (pSelectedUnit == NULL)
+			continue;
+
+		eRivalTeam = pSelectedUnit->getDeclareWarUnitMove(pPlot);
+
+		// cargo ships skip. troop ships still ask for Europeans.
+		if (eRivalTeam != NO_TEAM && (pSelectedUnit->cargoSpace() == 0 || pSelectedUnit->getUnitInfo().isTroopShip()))
+		{
+			const PlayerTypes eRivalLeader = GET_TEAM(eRivalTeam).getLeaderID();
+			// natives: no ask, no auto-war. just MOVE_TO. war stays on the diplomacy screen.
+			if (eRivalLeader != NO_PLAYER && GET_PLAYER(eRivalLeader).isNative())
+			{
+				break;
+			}
+
+			CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_DECLAREWARMOVE);
+			if (NULL != pInfo)
+			{
+				pInfo->setData1(eRivalTeam);
+				pInfo->setData2(pPlot->getX());
+				pInfo->setData3(pPlot->getY());
+				pInfo->setOption1(bShift);
+				if (pPlot->isOwned())
+				{
+					pInfo->setOption2(pSelectedUnit->canEnterTerritory(pPlot->getOwnerINLINE()));
+				}
+				else
+				{
+					pInfo->setOption2(true);
+				}
+				gDLL->getInterfaceIFace()->addPopup(pInfo);
+			}
+			return;
+		}
+	}
+
 	selectionListGameNetMessage(GAMEMESSAGE_PUSH_MISSION, MISSION_MOVE_TO, pPlot->getX(), pPlot->getY(), 0, false, bShift);
 }
 


### PR DESCRIPTION
Native villages no longer ask "does this mean war?" when a military unit moves onto them. European territory still asks, same as before.

1. natives: no popup, no auto-war. MOVE_TO goes through. declare war from the diplomacy screen, then move in to fight
2. Europeans: the popup is unchanged. Yes declares war and moves. No moves only if the tile can be entered without war
3. cargo ships still skip. troop ships still get the European popup
4. refuse-to-talk still offers Declare War in diplomacy when canDeclareWar is true (and Revolution vs the king)
5. DLL. rebuild the DLL