### PR TITLE
Reduced Colony Distance for 2-plot radius

### DIFF
--- a/Assets/XML/Text/XML_AUTO_UTF8_GameOptionInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_GameOptionInfo.xml
@@ -337,12 +337,12 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_GAMEOPTION_REDUCED_CITY_DISTANCE_HELP</Tag>
-		<English>Reduce the minimum distance to other colonies by 1 if the player already owns the founding plot and all plots next to it (3x3 grid).</English>
-		<French>Réduire la distance minimale aux autres colonies de 1 si le joueur possède déjà la parcelle fondatrice et toutes les parcelles voisines (grille 3x3).</French>
-		<German>Verringert den Mindestabstand zu anderen Kolonien um 1, wenn der Spieler bereits die Gründungsparzelle und alle angrenzenden Parzellen besitzt (3x3-Raster).</German>
-		<Italian>Ridurre la distanza minima dalle altre colonie di 1 se il giocatore possiede già il lotto fondatore e tutti i lotti vicini (griglia 3x3).</Italian>
-		<Spanish>Reducir la distancia mínima a otras colonias en 1 si el jugador ya posee la parcela fundadora y todas las parcelas contiguas (cuadrícula 3x3).</Spanish>
-		<Russian>Уменьшает минимальное расстояние до других колоний на 1 клетку, если игрок уже владеет участком основания и всеми участками рядом с ним (сетка 3x3).</Russian>
+		<English>Reduce the minimum distance to other colonies by 1.</English>
+		<French>Réduire la distance minimale aux autres colonies de 1.</French>
+		<German>Verringert den Mindestabstand zu anderen Kolonien um 1.</German>
+		<Italian>Ridurre la distanza minima dalle altre colonie di 1.</Italian>
+		<Spanish>Reducir la distancia mínima a otras colonias en 1.</Spanish>
+		<Russian>Уменьшает минимальное расстояние до других колоний на 1 клетку.</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_GAMEOPTION_REMOVE_WORLD_BUILDER</Tag>

--- a/Project Files/DLLSources/CvDLLWidgetData.cpp
+++ b/Project Files/DLLSources/CvDLLWidgetData.cpp
@@ -1970,11 +1970,7 @@ void CvDLLWidgetData::parseActionHelp(const CvWidgetDataStruct &widgetDataStruct
 				{
 					bValid = true;
 
-					iRange = GC.getMIN_CITY_RANGE();
-					if (GC.getGameINLINE().isOption(GAMEOPTION_REDUCED_CITY_DISTANCE) && iRange > 1)
-					{
-						--iRange;
-					}
+					iRange = GET_PLAYER(pHeadSelectedUnit->getOwnerINLINE()).getFoundCityMinRange(pMissionPlot);
 
 					for (iDX = -(iRange); iDX <= iRange; iDX++)
 					{

--- a/Project Files/DLLSources/CvDLLWidgetData.cpp
+++ b/Project Files/DLLSources/CvDLLWidgetData.cpp
@@ -1971,6 +1971,10 @@ void CvDLLWidgetData::parseActionHelp(const CvWidgetDataStruct &widgetDataStruct
 					bValid = true;
 
 					iRange = GC.getMIN_CITY_RANGE();
+					if (GC.getGameINLINE().isOption(GAMEOPTION_REDUCED_CITY_DISTANCE) && iRange > 1)
+					{
+						--iRange;
+					}
 
 					for (iDX = -(iRange); iDX <= iRange; iDX++)
 					{
@@ -1991,7 +1995,7 @@ void CvDLLWidgetData::parseActionHelp(const CvWidgetDataStruct &widgetDataStruct
 					if (!bValid)
 					{
 						szBuffer.append(NEWLINE);
-						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CANNOT_FOUND", GC.getMIN_CITY_RANGE()));
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CANNOT_FOUND", iRange));
 					}
 				}
 			}

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -6094,7 +6094,8 @@ int CvPlayer::getFoundCityMinRange(const CvPlot* pPlot) const
 
 	// 2-plot radius: always reduce by 1. 1-plot keeps the 3x3 ownership check
 	// so close colonies are for filling gaps, not the first wave.
-	if (GC.getGameINLINE().isOption(GAMEOPTION_TWO_PLOT_CITY_RADIUS))
+	// Use CITY_PLOTS_RADIUS: random maps can set radius without the game option.
+	if (CITY_PLOTS_RADIUS == 2)
 	{
 		return iRange - 1;
 	}

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -6192,28 +6192,10 @@ bool CvPlayer::canFound(Coordinates foundCoord, bool bTestVisible) const
 	if (!bTestVisible)
 	{
 		iRange = GC.getMIN_CITY_RANGE();
-
-		/// reduced city distance - start - Nightinggale
-		if (GC.getGameINLINE().isOption(GAMEOPTION_REDUCED_CITY_DISTANCE))
+		if (GC.getGameINLINE().isOption(GAMEOPTION_REDUCED_CITY_DISTANCE) && iRange > 1)
 		{
-			bool bOwnsAll = true;
-			for (iDX = -1; iDX <= 1 && bOwnsAll; iDX++)
-			{
-				for (iDY = -1; iDY <= 1 && bOwnsAll; iDY++)
-				{
-					pLoopPlot = (pPlot->coord() + RelCoordinates(iDX, iDY)).plot();
-					if (pLoopPlot != NULL && pLoopPlot->getOwnerINLINE() != getID())
-					{
-						bOwnsAll = false;
-					}
-				}
-			}
-			if (bOwnsAll)
-			{
-				--iRange;
-			}
+			--iRange;
 		}
-		/// reduced city distance - end - Nightinggale
 
 		for (iDX = -(iRange); iDX <= iRange; iDX++)
 		{

--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -6084,6 +6084,41 @@ void CvPlayer::doGoody(CvPlot* pPlot, CvUnit* pUnit)
 }
 
 
+int CvPlayer::getFoundCityMinRange(const CvPlot* pPlot) const
+{
+	int iRange = GC.getMIN_CITY_RANGE();
+	if (!GC.getGameINLINE().isOption(GAMEOPTION_REDUCED_CITY_DISTANCE) || iRange <= 1)
+	{
+		return iRange;
+	}
+
+	// 2-plot radius: always reduce by 1. 1-plot keeps the 3x3 ownership check
+	// so close colonies are for filling gaps, not the first wave.
+	if (GC.getGameINLINE().isOption(GAMEOPTION_TWO_PLOT_CITY_RADIUS))
+	{
+		return iRange - 1;
+	}
+
+	if (pPlot == NULL)
+	{
+		return iRange;
+	}
+
+	for (int iDX = -1; iDX <= 1; ++iDX)
+	{
+		for (int iDY = -1; iDY <= 1; ++iDY)
+		{
+			CvPlot* pLoopPlot = (pPlot->coord() + RelCoordinates(iDX, iDY)).plot();
+			if (pLoopPlot != NULL && pLoopPlot->getOwnerINLINE() != getID())
+			{
+				return iRange;
+			}
+		}
+	}
+
+	return iRange - 1;
+}
+
 bool CvPlayer::canFound(Coordinates foundCoord, bool bTestVisible) const
 {
 	CvPlot* pPlot;
@@ -6191,11 +6226,7 @@ bool CvPlayer::canFound(Coordinates foundCoord, bool bTestVisible) const
 
 	if (!bTestVisible)
 	{
-		iRange = GC.getMIN_CITY_RANGE();
-		if (GC.getGameINLINE().isOption(GAMEOPTION_REDUCED_CITY_DISTANCE) && iRange > 1)
-		{
-			--iRange;
-		}
+		iRange = getFoundCityMinRange(pPlot);
 
 		for (iDX = -(iRange); iDX <= iRange; iDX++)
 		{

--- a/Project Files/DLLSources/CvPlayer.h
+++ b/Project Files/DLLSources/CvPlayer.h
@@ -321,6 +321,7 @@ public:
 	void receiveRandomGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit);
 	void doGoody(CvPlot* pPlot, CvUnit* pUnit);
 	bool canFound(Coordinates foundCoord, bool bTestVisible = false) const;
+	int getFoundCityMinRange(const CvPlot* pPlot) const;
 	CvCity *found(Coordinates foundCoord);
 	bool canTrain(UnitTypes eUnit, bool bContinue = false, bool bTestVisible = false, bool bIgnoreCost = false) const;
 	bool canConstruct(BuildingTypes eBuilding, bool bContinue = false, bool bTestVisible = false, bool bIgnoreCost = false) const;


### PR DESCRIPTION
1. Reduced Colony Distance was only dropping the min founding range if you already owned the 3x3 around the new site. with 2-plot city that still blocked founding at 3 plots on empty land.

2. with 2-plot radius the option now always reduces min distance by 1 (closest city is 3 plots). 1-plot radius is unchanged: still needs the owned 3x3.

3. needs a new DLL. the compiled binary is not in this PR. existing saves keep the option, just restart.