### PR TITLE
Show game-speed-scaled waits on pirate event help

### DIFF
--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -5478,6 +5478,20 @@ def _getPiratesScaledTurns(iBaseTurns):
 	iPercent = gc.getGameSpeedInfo(gameSpeedType).getGrowthPercent()
 	return max(1, int((iBaseTurns * iPercent) / 100))
 
+def _getPiratesFollowupChanceAndDelay(event, szFollowupType):
+	# 1. EventTimes in XML is the standard-speed wait.
+	# 2. applyEvent scales that by growth percent, so the option help has to do the same.
+	eFollowup = gc.getInfoTypeForString(szFollowupType)
+	if eFollowup == -1:
+		return 0, 0
+
+	iChance = event.getAdditionalEventChance(eFollowup)
+	iTime = event.getAdditionalEventTime(eFollowup)
+	if iTime <= 0:
+		return iChance, 0
+
+	return iChance, _getPiratesScaledTurns(iTime)
+
 def _startPiratesSoftCooldown(player, iBaseTurns):
 	if player.isNone():
 		return
@@ -5730,7 +5744,13 @@ def canTriggerPirates(argsList):
 	return True
 
 def getHelpPirates1(argsList):
-	return localText.getText("TXT_KEY_EVENT_PIRATES_1_HELP", ())
+	eEvent = argsList[1]
+	event = gc.getEventInfo(eEvent)
+	iDelay = _getPiratesFollowupChanceAndDelay(event, "EVENT_PIRATES_1a")[1]
+	if iDelay <= 0:
+		# XML EventTimes for EVENT_PIRATES_1a is 5 on standard speed.
+		iDelay = _getPiratesScaledTurns(5)
+	return localText.getText("TXT_KEY_EVENT_PIRATES_1_HELP", (iDelay,))
 
 def CanDoPirates3(argsList):
 	kTriggeredData = argsList[0]
@@ -5841,6 +5861,22 @@ def getHelpPirates4(argsList):
 	szHelp = u""
 	if iAmount != 0:
 		szHelp = localText.getText("TXT_KEY_EVENT_YIELD_LOOSE", (iAmount, gc.getYieldInfo(iYield).getChar(), city.getNameKey()))
+
+	# 1. muskets already use storage percent.
+	# 2. the ship wait uses growth percent, same formula applyEvent uses.
+	# 3. 4a also has 1 revolt turn (3 on marathon), which looks like the wait if we don't print this.
+	iChance, iDelay = _getPiratesFollowupChanceAndDelay(event, "EVENT_PIRATES_4a")
+	if iChance > 0 and iDelay > 0:
+		szShip = u""
+		iRewardUnitClass = getPrivateerRewardUnitClass3(player)
+		if iRewardUnitClass != -1:
+			iRewardUnit = gc.getCivilizationInfo(player.getCivilizationType()).getCivilizationUnits(iRewardUnitClass)
+			if iRewardUnit != -1:
+				szShip = gc.getUnitInfo(iRewardUnit).getDescription()
+		if szShip != u"":
+			if szHelp != u"":
+				szHelp += u"\n"
+			szHelp += localText.getText("TXT_KEY_EVENT_PIRATES_4_FOLLOWUP_HELP", (iChance, iDelay, szShip))
 
 	return szHelp
 

--- a/Assets/XML/Text/CIV4GameTextInfos_Original_utf8.xml
+++ b/Assets/XML/Text/CIV4GameTextInfos_Original_utf8.xml
@@ -12020,7 +12020,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_DELAY_TURNS</Tag>
 		<English>, in %d1 [NUM1:turn:turns]</English>
-		<Portuguese>, in %d1 [NUM1:turno:turnos]</Portuguese>
+		<Portuguese>, em %d1 [NUM1:turno:turnos]</Portuguese>
 		<French>, dans %d1 [NUM1:tour:tours]</French>
 		<German> in %d1 [NUM1:Runde:Runden]</German>
 		<Italian>, in %d1 [NUM1:turno:turni]</Italian>

--- a/Assets/XML/Text/CIV4GameText_Colonization_Events_utf8.xml
+++ b/Assets/XML/Text/CIV4GameText_Colonization_Events_utf8.xml
@@ -2699,10 +2699,17 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_PIRATES_1_HELP</Tag>
-		<English>If this treasure is still in the harbor after 5 turns, the pirates will steal it. If you move it away in time, a Pirate Cutter will appear off the coast instead.</English>
-		<Portuguese>Se este tesouro ainda estiver no porto após 5 turnos, os piratas irão roubá-lo. Se você afastá-lo a tempo, um Cúter Pirata aparecerá na costa.</Portuguese>
-		<German>Wenn sich dieser Schatz nach 5 Runden noch immer im Hafen befindet, werden die Piraten ihn stehlen. Bringst du ihn rechtzeitig fort, werden die Piraten vor der Küste lauern.</German>
-		<Russian>Если через 5 ходов это Сокровище будет находиться в гавани, его украдут пираты. Если же вы успеете его убрать, у берегов появится Пиратский катер.</Russian>
+		<English>If this treasure is still in the harbor after %d1 [NUM1:turn:turns], the pirates will steal it. If you move it away in time, a Pirate Cutter will appear off the coast instead.</English>
+		<Portuguese>Se este tesouro ainda estiver no porto após %d1 [NUM1:turno:turnos], os piratas irão roubá-lo. Se você afastá-lo a tempo, um Cúter Pirata aparecerá na costa.</Portuguese>
+		<German>Wenn sich dieser Schatz nach %d1 [NUM1:Runde:Runden] noch immer im Hafen befindet, werden die Piraten ihn stehlen. Bringst du ihn rechtzeitig fort, werden die Piraten vor der Küste lauern.</German>
+		<Russian>Если через %d1 [NUM1:ход:ходов] это Сокровище будет находиться в гавани, его украдут пираты. Если же вы успеете его убрать, у берегов появится Пиратский катер.</Russian>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_EVENT_PIRATES_4_FOLLOWUP_HELP</Tag>
+		<English>[ICON_BULLET]%d1%% chance, in %d2 [NUM2:turn:turns], to receive a [COLOR_HIGHLIGHT_TEXT]%s3[COLOR_REVERT] in one of our colonies.</English>
+		<Portuguese>[ICON_BULLET]%d1%% de chance, em %d2 [NUM2:turno:turnos], de receber um [COLOR_HIGHLIGHT_TEXT]%s3[COLOR_REVERT] em uma de nossas colônias.</Portuguese>
+		<German>[ICON_BULLET]%d1%% Wahrscheinlichkeit, in %d2 [NUM2:Runde:Runden] ein bzw. eine [COLOR_HIGHLIGHT_TEXT]%s3[COLOR_REVERT] in einer unserer Kolonien zu erhalten.</German>
+		<Russian>[ICON_BULLET]%d1%% шанс через %d2 [NUM2:ход:ходов] получить [COLOR_HIGHLIGHT_TEXT]%s3[COLOR_REVERT] в одной из наших колоний.</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_PIRATES_1a</Tag>


### PR DESCRIPTION
## Problem

On a Marathon playthrough, the harbor pirate event offered to spend 150 muskets for an 80% chance of a pirate ship. The musket cost was already scaled correctly (50 x StoragePercent), but the option help never stated the wait for the ship.

EVENT_PIRATES_4a waits iEventTime 5, which applyEvent scales by GrowthPercent. On Marathon that is 15 turns. The follow-up also has iRevoltTurns 1, which the generic event help scales to 3 turns of disorder. That 3 is the number that showed up as a wait, so the option looked like a 3-turn ship instead of 15.

The same popup's treasure option hardcoded "after 5 turns" in every language, so Marathon still read 5 there as well. Portuguese TXT_KEY_EVENT_DELAY_TURNS still said "in" instead of "em".

## Fix

- getHelpPirates4 now prints the 80% ship chance with the same GrowthPercent delay applyEvent uses.
- getHelpPirates1 / TXT_KEY_EVENT_PIRATES_1_HELP take the scaled wait instead of a hardcoded 5.
- Portuguese delay fragment is "em %d1 turnos".

Python and XML only. Restart the game (or reload the mod) to pick this up. No DLL change.

The 80% roll still happens immediately when the option is accepted. The remaining 20% does not schedule a follow-up and has no fail popup. That part is unchanged.

## Test

- Marathon: muskets option should show 150 muskets and 15 turns for the 80% ship. Treasure option should say 15 turns, not 5.
- Normal speed should still show 5.