### PR TITLE
Score every yield when the AI values an event

### DIFF
--- a/Project Files/DLLSources/CvPlayerAI.cpp
+++ b/Project Files/DLLSources/CvPlayerAI.cpp
@@ -12913,10 +12913,34 @@ int CvPlayerAI::AI_eventValue(EventTypes eEvent, const EventTriggeredData& kTrig
 		}
 	}
 
+	// Score every yield that was collected. The old city-effect path only
+	// added food/bells/crosses, and the global path never added aiYields at
+	// all, so events like EVENT_BOOK_MORMON_2 looked worthless to the AI.
+	int iYieldTurnValue = 0;
+	for (int iYield = 0; iYield < NUM_YIELD_TYPES; ++iYield)
+	{
+		if (aiYields[iYield] != 0)
+		{
+			int iWeight = 2;
+			if (iYield == YIELD_FOOD)
+			{
+				iWeight = 5;
+			}
+			else if (iYield == YIELD_BELLS)
+			{
+				iWeight = 3;
+			}
+			else if (iYield == YIELD_CROSSES)
+			{
+				iWeight = 1;
+			}
+			iYieldTurnValue += aiYields[iYield] * iWeight;
+		}
+	}
+
 	if (kEvent.isCityEffect())
 	{
 		int iCityPopulation = -1;
-		int iCityTurnValue = 0;
 		if (NULL != pCity)
 		{
 			iCityPopulation = pCity->getPopulation();
@@ -12928,12 +12952,7 @@ int CvPlayerAI::AI_eventValue(EventTypes eEvent, const EventTriggeredData& kTrig
 			iCityPopulation = 5;
 		}
 
-		iCityTurnValue += aiYields[YIELD_FOOD] * 5;
-
-		iCityTurnValue += aiYields[YIELD_BELLS] * 3;
-		iCityTurnValue += aiYields[YIELD_CROSSES] * 1;
-
-		iValue += (iCityTurnValue * 20 * iGameSpeedPercent) / 100;
+		iValue += (iYieldTurnValue * 20 * iGameSpeedPercent) / 100;
 
 		iValue += kEvent.getFood();
 		iValue += kEvent.getFoodPercent() / 4;
@@ -12944,9 +12963,7 @@ int CvPlayerAI::AI_eventValue(EventTypes eEvent, const EventTriggeredData& kTrig
 	}
 	else if (!kEvent.isOtherPlayerCityEffect())
 	{
-		int iPerTurnValue = 0;
-
-		iValue += (iPerTurnValue * 20 * iGameSpeedPercent) / 100;
+		iValue += (iNumCities * iYieldTurnValue * 20 * iGameSpeedPercent) / 100;
 
 		iValue += (kEvent.getFood() * iNumCities);
 		iValue += (kEvent.getFoodPercent() * iNumCities) / 4;


### PR DESCRIPTION
`AI_eventValue` adds building yield changes into `aiYields`, then mostly ignores them.

City-pick events only scored food, bells and crosses. Global events (`bPickCity` 0) scored nothing from `aiYields`, so `EVENT_BOOK_MORMON_2` (crosses on halls) looked worthless to the AI.

Every yield is now scored. Food / bells / crosses keep the old weights. Other yields use 2. Global events multiply by city count, same as food and culture on that path.

Needs a rebuilt DLL.

Fixes #1175