### PR TITLE
Do not fail untracked quests when a stored unit is gone

### DIFF
--- a/Project Files/DLLSources/CvPlayer.cpp
+++ b/Project Files/DLLSources/CvPlayer.cpp
@@ -16176,7 +16176,12 @@ bool CvPlayer::checkExpireEvent(EventTypes eEvent, const EventTriggeredData& kTr
 		}
 	}
 
-	if (kTriggeredData.m_iUnitId != -1)
+	// Only fail the quest because the stored unit is gone when the trigger
+	// asked to track that unit. Start triggers like six warships / slave
+	// barques pick a unit to test "you have N of these", but bTrackUnit is
+	// 0: giving the king that frigate, or assigning that slave to a city,
+	// must not fail the unrelated quest.
+	if (kTriggeredData.m_iUnitId != -1 && kTrigger.unitTriggers().Tracked)
 	{
 		if (NULL == kPlayer.getUnit(kTriggeredData.m_iUnitId))
 		{


### PR DESCRIPTION
`checkExpireEvent` failed any quest whose stored `m_iUnitId` unit was gone.

The six-warships and slave-barque *start* triggers pick a unit only to test "you have N of these". `bTrackUnit` is 0 on those. Giving the king that frigate (commandeered event kills it) or assigning that slave to a city then failed the unrelated quest.

Expire on a missing unit only if the trigger asked to track it.

Needs a rebuilt DLL.

Fixes #1068