### PR TITLE
Name the planted forest, not the tundra terrain

### DIFF
--- a/Assets/XML/Text/XML_AUTO_UTF8_BuildInfo.xml
+++ b/Assets/XML/Text/XML_AUTO_UTF8_BuildInfo.xml
@@ -370,11 +370,11 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILD_REFORESTATION_TUNDRA</Tag>
-		<English>Plant tundra</English>
-		<Portuguese>Plantar tundra</Portuguese>
-		<French>Planter une taïga</French>
-		<German>Taiga aufforsten</German>
-		<Russian>Высадить [COLOR_HIGHLIGHT_TEXT]тундру[COLOR_REVERT]</Russian>
+		<English>Plant northern forest</English>
+		<Portuguese>Plantar floresta boreal</Portuguese>
+		<French>Planter une forêt boréale</French>
+		<German>Nordwald aufforsten</German>
+		<Russian>Высадить [COLOR_HIGHLIGHT_TEXT]северный лес[COLOR_REVERT]</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILD_REFORESTATION_TUNDRA_HELP</Tag>


### PR DESCRIPTION
The tundra reforestation button said "Plant tundra". It plants `FEATURE_FOREST_TUNDRA` (Northern Forest), not the base terrain.

English / Portuguese / French / German / Russian now name the forest, matching the feature text and the expected "Plant northern forest".

XML text only. Restart the game. No DLL rebuild.

Fixes #1016