### PR TITLE
Only let a unit that can talk pick the chief

### DIFF
--- a/Project Files/DLLSources/CvDLLButtonPopup.cpp
+++ b/Project Files/DLLSources/CvDLLButtonPopup.cpp
@@ -3904,7 +3904,7 @@ bool CvDLLButtonPopup::launchTalkNativesPopup(CvPopup* pPopup, CvPopupInfo& info
 	gDLL->getInterfaceIFace()->popupSetBodyString(pPopup, gDLL->getText("TXT_KEY_TALK_NATIVES_POPUP", pCity->getNameKey()));
 
 	int iNumActions = 0;
-	if (pUnit->canSpeakWithChief(pUnit->plot()))
+	if (pUnit->canDoCommand(COMMAND_SPEAK_WITH_CHIEF, -1, -1, false, false))
 	{
 		++iNumActions;
 		gDLL->getInterfaceIFace()->popupAddGenericButton(pPopup, gDLL->getText("TXT_KEY_TALK_NATIVES_POPUP_CHIEF"), NULL, COMMAND_SPEAK_WITH_CHIEF);

--- a/Project Files/DLLSources/CvSelectionGroup.cpp
+++ b/Project Files/DLLSources/CvSelectionGroup.cpp
@@ -4474,16 +4474,11 @@ void CvSelectionGroup::speakWithChief()
 	{
 		CvUnit* pLoopUnit = ::getUnit(pUnitNode->m_data);
 
-		if (pLoopUnit != NULL)
+		if (pLoopUnit != NULL && pLoopUnit->canSpeakWithChief(plot()))
 		{
-			if (pLoopUnit->canSpeakWithChief(plot())) //first best
+			pBestUnit = pLoopUnit;
+			if (pLoopUnit->isNoBadGoodies()) // scout beats a colonist in the same selection
 			{
-				pBestUnit = pLoopUnit;
-			}
-
-			if (pLoopUnit->isNoBadGoodies()) //found absolute best
-			{
-				pBestUnit = pLoopUnit;
 				break;
 			}
 		}

--- a/Project Files/DLLSources/CvUnit.cpp
+++ b/Project Files/DLLSources/CvUnit.cpp
@@ -2931,6 +2931,22 @@ bool CvUnit::canDoCommand(CommandTypes eCommand, int iData1, int iData2, bool bT
 		{
 			return true;
 		}
+		// Mixed selection: the exe enables the button from the head unit.
+		// Treasure/wagon as head would disable Talk to Chief even when a
+		// failed trader in the same group can speak.
+		if (getGroup() != NULL)
+		{
+			CLLNode<IDInfo>* pUnitNode = getGroup()->headUnitNode();
+			while (pUnitNode != NULL)
+			{
+				CvUnit* pLoopUnit = ::getUnit(pUnitNode->m_data);
+				pUnitNode = getGroup()->nextUnitNode(pUnitNode);
+				if (pLoopUnit != NULL && pLoopUnit != this && pLoopUnit->canSpeakWithChief(plot()))
+				{
+					return true;
+				}
+			}
+		}
 		break;
 
 	case COMMAND_HOTKEY:
@@ -3383,7 +3399,7 @@ void CvUnit::doCommand(CommandTypes eCommand, int iData1, int iData2)
 		// R&R, ray , Stirring Up Natives - END
 
 		case COMMAND_SPEAK_WITH_CHIEF:
-			if (isGroupHead())
+			if (getGroup() != NULL)
 			{
 				getGroup()->speakWithChief();
 			}


### PR DESCRIPTION
`speakWithChief` on a mixed selection could pick `isNoBadGoodies` even when that unit cannot talk (treasure, wagon, goods).

A treasure listed ahead of a failed trader then did nothing when you clicked talk to the chief.

Only units that `canSpeakWithChief` are considered. A scout in the same selection is still preferred.

Needs a rebuilt DLL.

Fixes #1030