### PR TITLE
Show open town jobs on the graduation popup

### DIFF
--- a/Project Files/DLLSources/CvDLLButtonPopup.cpp
+++ b/Project Files/DLLSources/CvDLLButtonPopup.cpp
@@ -2194,6 +2194,86 @@ bool CvDLLButtonPopup::launchChooseYieldBuildPopup(CvPopup* pPopup, CvPopupInfo 
 	return (true);
 }
 
+static ProfessionTypes getProfessionForEducatedUnit(UnitTypes eUnit)
+{
+	const UnitClassTypes eUnitClass = GC.getUnitInfo(eUnit).getUnitClassType();
+	for (ProfessionTypes eProfession = FIRST_PROFESSION; eProfession < NUM_PROFESSION_TYPES; ++eProfession)
+	{
+		const CvProfessionInfo& kProfession = GC.getProfessionInfo(eProfession);
+		if (kProfession.isCitizen() && kProfession.LbD_getExpert() == eUnitClass)
+		{
+			return eProfession;
+		}
+	}
+	return NO_PROFESSION;
+}
+
+// Empty jobs across all towns. Building jobs: unused special-building slots.
+// Plot jobs: unused city plots that produce that yield.
+static int countOpenProfessionSlots(const CvPlayer& kPlayer, ProfessionTypes eProfession)
+{
+	if (eProfession == NO_PROFESSION)
+	{
+		return -1;
+	}
+
+	const CvProfessionInfo& kProfession = GC.getProfessionInfo(eProfession);
+	if (!kProfession.isCitizen())
+	{
+		return -1;
+	}
+
+	int iOpen = 0;
+	int iLoop;
+	for (CvCity* pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
+	{
+		if (kProfession.isWorkPlot())
+		{
+			const YieldTypes eYield = (YieldTypes) kProfession.getYieldsProduced(0);
+			FOREACH(CityPlot)
+			{
+				if (eLoopCityPlot == CITY_HOME_PLOT || pLoopCity->isPlotProducingYields(eLoopCityPlot))
+				{
+					continue;
+				}
+				CvPlot* pLoopPlot = pLoopCity->getCityIndexPlot(eLoopCityPlot);
+				if (pLoopPlot != NULL && pLoopCity->canWork(pLoopPlot))
+				{
+					if (eYield == NO_YIELD || pLoopPlot->calculateYield(eYield, false) > 0)
+					{
+						++iOpen;
+					}
+				}
+			}
+		}
+		else
+		{
+			int iSlots = pLoopCity->getNumProfessionBuildingSlots(eProfession);
+			const int iSpecialBuilding = kProfession.getSpecialBuilding();
+			if (iSpecialBuilding != NO_SPECIALBUILDING)
+			{
+				for (int i = 0; i < pLoopCity->getPopulation(); ++i)
+				{
+					CvUnit* pCitizen = pLoopCity->getPopulationUnitByIndex(i);
+					if (pCitizen != NULL && pCitizen->getProfession() != NO_PROFESSION)
+					{
+						if (GC.getProfessionInfo(pCitizen->getProfession()).getSpecialBuilding() == iSpecialBuilding)
+						{
+							--iSlots;
+						}
+					}
+				}
+			}
+			if (iSlots > 0)
+			{
+				iOpen += iSlots;
+			}
+		}
+	}
+
+	return iOpen;
+}
+
 bool CvDLLButtonPopup::launchEducationPopup(CvPopup* pPopup, CvPopupInfo &info)
 {
 	CvPlayer& kPlayer = GET_PLAYER(GC.getGameINLINE().getActivePlayer());
@@ -2222,6 +2302,11 @@ bool CvDLLButtonPopup::launchEducationPopup(CvPopup* pPopup, CvPopupInfo &info)
 		if (iPrice >= 0 && iPrice <= kPlayer.getGold())
 		{
 			szText.Format(L"%s", kUnit.getDescription());
+			const int iOpenSlots = countOpenProfessionSlots(kPlayer, getProfessionForEducatedUnit(eUnitType));
+			if (iOpenSlots >= 0)
+			{
+				szText += CvWString::format(L" (%d)", iOpenSlots);
+			}
 			if (iPrice > 0)
 			{
 				szText += CvWString::format(L" (%d%c)", iPrice, GC.getSymbolID(GOLD_CHAR));

--- a/Project Files/DLLSources/CvDLLButtonPopup.cpp
+++ b/Project Files/DLLSources/CvDLLButtonPopup.cpp
@@ -2208,8 +2208,20 @@ static ProfessionTypes getProfessionForEducatedUnit(UnitTypes eUnit)
 	return NO_PROFESSION;
 }
 
-// Empty jobs across all towns. Building jobs: unused special-building slots.
-// Plot jobs: unused city plots that produce that yield.
+static bool isExpertForProfession(const CvUnit* pUnit, ProfessionTypes eProfession)
+{
+	if (pUnit == NULL || eProfession == NO_PROFESSION)
+	{
+		return false;
+	}
+	return GC.getProfessionInfo(eProfession).LbD_getExpert() == pUnit->getUnitClassType();
+}
+
+// Jobs a new specialist could usefully take across all towns.
+// Empty slots count. So do slots/plots already worked by a non-expert
+// (a free colonist in the carpenter shop is still a carpenter opening).
+// Shared workplaces (several butcher professions, one meat building):
+// only another specialist already working that building fills a slot.
 static int countOpenProfessionSlots(const CvPlayer& kPlayer, ProfessionTypes eProfession)
 {
 	if (eProfession == NO_PROFESSION)
@@ -2232,14 +2244,27 @@ static int countOpenProfessionSlots(const CvPlayer& kPlayer, ProfessionTypes ePr
 			const YieldTypes eYield = (YieldTypes) kProfession.getYieldsProduced(0);
 			FOREACH(CityPlot)
 			{
-				if (eLoopCityPlot == CITY_HOME_PLOT || pLoopCity->isPlotProducingYields(eLoopCityPlot))
+				if (eLoopCityPlot == CITY_HOME_PLOT)
 				{
 					continue;
 				}
 				CvPlot* pLoopPlot = pLoopCity->getCityIndexPlot(eLoopCityPlot);
-				if (pLoopPlot != NULL && pLoopCity->canWork(pLoopPlot))
+				if (pLoopPlot == NULL || !pLoopCity->canWork(pLoopPlot))
 				{
-					if (eYield == NO_YIELD || pLoopPlot->calculateYield(eYield, false) > 0)
+					continue;
+				}
+				if (eYield != NO_YIELD && pLoopPlot->calculateYield(eYield, false) <= 0)
+				{
+					continue;
+				}
+				if (!pLoopCity->isPlotProducingYields(eLoopCityPlot))
+				{
+					++iOpen;
+				}
+				else
+				{
+					CvUnit* pWorker = pLoopCity->getUnitWorkingPlot(eLoopCityPlot);
+					if (pWorker != NULL && pWorker->getProfession() == eProfession && !isExpertForProfession(pWorker, eProfession))
 					{
 						++iOpen;
 					}
@@ -2255,12 +2280,18 @@ static int countOpenProfessionSlots(const CvPlayer& kPlayer, ProfessionTypes ePr
 				for (int i = 0; i < pLoopCity->getPopulation(); ++i)
 				{
 					CvUnit* pCitizen = pLoopCity->getPopulationUnitByIndex(i);
-					if (pCitizen != NULL && pCitizen->getProfession() != NO_PROFESSION)
+					if (pCitizen == NULL || pCitizen->getProfession() == NO_PROFESSION)
 					{
-						if (GC.getProfessionInfo(pCitizen->getProfession()).getSpecialBuilding() == iSpecialBuilding)
-						{
-							--iSlots;
-						}
+						continue;
+					}
+					const CvProfessionInfo& kCitizenProfession = GC.getProfessionInfo(pCitizen->getProfession());
+					if (kCitizenProfession.getSpecialBuilding() != iSpecialBuilding)
+					{
+						continue;
+					}
+					if (isExpertForProfession(pCitizen, pCitizen->getProfession()))
+					{
+						--iSlots;
 					}
 				}
 			}

--- a/Project Files/DLLSources/CvDLLButtonPopup.cpp
+++ b/Project Files/DLLSources/CvDLLButtonPopup.cpp
@@ -2242,32 +2242,34 @@ static int countOpenProfessionSlots(const CvPlayer& kPlayer, ProfessionTypes ePr
 		if (kProfession.isWorkPlot())
 		{
 			const YieldTypes eYield = (YieldTypes) kProfession.getYieldsProduced(0);
+
 			FOREACH(CityPlot)
 			{
 				if (eLoopCityPlot == CITY_HOME_PLOT)
 				{
 					continue;
 				}
+
 				CvPlot* pLoopPlot = pLoopCity->getCityIndexPlot(eLoopCityPlot);
 				if (pLoopPlot == NULL || !pLoopCity->canWork(pLoopPlot))
 				{
 					continue;
 				}
+
+				if (pLoopPlot->isWater() != kProfession.isWater())
+				{
+					continue;
+				}
+
 				if (eYield != NO_YIELD && pLoopPlot->calculateYield(eYield, false) <= 0)
 				{
 					continue;
 				}
-				if (!pLoopCity->isPlotProducingYields(eLoopCityPlot))
+
+				CvUnit* pWorker = pLoopCity->getUnitWorkingPlot(eLoopCityPlot);
+				if (pWorker == NULL || !isExpertForProfession(pWorker, eProfession))
 				{
 					++iOpen;
-				}
-				else
-				{
-					CvUnit* pWorker = pLoopCity->getUnitWorkingPlot(eLoopCityPlot);
-					if (pWorker != NULL && pWorker->getProfession() == eProfession && !isExpertForProfession(pWorker, eProfession))
-					{
-						++iOpen;
-					}
 				}
 			}
 		}
@@ -2284,17 +2286,20 @@ static int countOpenProfessionSlots(const CvPlayer& kPlayer, ProfessionTypes ePr
 					{
 						continue;
 					}
+
 					const CvProfessionInfo& kCitizenProfession = GC.getProfessionInfo(pCitizen->getProfession());
 					if (kCitizenProfession.getSpecialBuilding() != iSpecialBuilding)
 					{
 						continue;
 					}
+
 					if (isExpertForProfession(pCitizen, pCitizen->getProfession()))
 					{
 						--iSlots;
 					}
 				}
 			}
+
 			if (iSlots > 0)
 			{
 				iOpen += iSlots;
@@ -4020,7 +4025,7 @@ bool CvDLLButtonPopup::launchTalkNativesPopup(CvPopup* pPopup, CvPopupInfo& info
 	gDLL->getInterfaceIFace()->popupSetBodyString(pPopup, gDLL->getText("TXT_KEY_TALK_NATIVES_POPUP", pCity->getNameKey()));
 
 	int iNumActions = 0;
-	if (pUnit->canSpeakWithChief(pUnit->plot()))
+	if (pUnit->canDoCommand(COMMAND_SPEAK_WITH_CHIEF, -1, -1, false, false))
 	{
 		++iNumActions;
 		gDLL->getInterfaceIFace()->popupAddGenericButton(pPopup, gDLL->getText("TXT_KEY_TALK_NATIVES_POPUP_CHIEF"), NULL, COMMAND_SPEAK_WITH_CHIEF);


### PR DESCRIPTION
The graduation popup listed expert names only. You had to open each town to see if a carpenter shop or fish plot was actually empty.

Each specialty now shows how many open jobs that expert can fill across your towns:

- Workshop professions (carpenter, weaver, ...): unused slots in that special building.
- Plot professions (farmer, fisherman, ...): unused city plots that produce that yield.

Example: `Master Carpenter (3)` means three empty carpenter-shop slots. Tuition gold still shows after that when the specialty costs money.

Needs a rebuilt DLL.